### PR TITLE
support custom headers of elastical client

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ var Elasticsearch = module.exports = winston.transports.Elasticsearch = function
   this.client = new elastical.Client( options.host || 'localhost', {
     port: options.port || 9200,
     auth: options.auth || '',
+    headers: options.headers,
     protocol: options.protocol || 'http',
     curlDebug: !!options.curlDebug,
     basePath: options.basePath || '', // <- ?
@@ -122,4 +123,3 @@ Elasticsearch.prototype.log = function log( level, msg, meta, callback ) {
   return this;
 
 };
-

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "elasticsearch"
   ],
   "dependencies": {
-    "elastical": "0.0.11",
+    "elastical": "0.0.13",
     "xtend": "~2.0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
* upgrade elastical to version 0.0.13 where it start to support `basePath` option.
* supports custom headers for custom authentication scheme.