### PR TITLE
Field names

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ Elasticsearch.prototype.log = function log( level, msg, meta, callback ) {
 
   // Add auto-generated fields unless disabled
   if( !this.disable_fields ) {
-    entry['fields'] = {
+    entry = xtend(entry, {
       worker: cluster.isWorker,
       pid: process.pid,
       path: module.parent.filename,
@@ -91,7 +91,7 @@ Elasticsearch.prototype.log = function log( level, msg, meta, callback ) {
       rss: process.memoryUsage().rss,
       heapTotal: process.memoryUsage().heapTotal,
       heapUsed: process.memoryUsage().heapUsed
-    };
+    });
   }
 
   // Add tags only if they exist
@@ -100,7 +100,7 @@ Elasticsearch.prototype.log = function log( level, msg, meta, callback ) {
   }
 
   if( meta ) {
-    entry['fields'] = xtend(entry['fields'], meta);
+    entry = xtend(entry, meta);
   }
 
 

--- a/index.js
+++ b/index.js
@@ -75,14 +75,13 @@ Elasticsearch.prototype.log = function log( level, msg, meta, callback ) {
   // Using some Logstash naming conventions. (https://gist.github.com/jordansissel/2996677) with some useful variables for debugging.
   var entry = {
     level: level,
-    '@source': self.source,
     '@timestamp': new Date().toISOString(),
-    '@message': msg
+    'message': msg
   }
 
   // Add auto-generated fields unless disabled
   if( !this.disable_fields ) {
-    entry['@fields'] = {
+    entry['fields'] = {
       worker: cluster.isWorker,
       pid: process.pid,
       path: module.parent.filename,
@@ -97,11 +96,11 @@ Elasticsearch.prototype.log = function log( level, msg, meta, callback ) {
 
   // Add tags only if they exist
   if( meta && meta.tags ) {
-    entry['@tags'] = meta && meta.tags;
+    entry['tags'] = meta && meta.tags;
   }
 
   if( meta ) {
-    entry['@fields'] = xtend(entry['@fields'], meta);
+    entry['fields'] = xtend(entry['fields'], meta);
   }
 
 


### PR DESCRIPTION
Changed field names according to new standard in logstash ( #6 ).
Accordingly, I've moved additional fields and `meta` fields from `@fields` to the entry itself, because, according to https://gist.github.com/jordansissel/2996677 "every other field is valid and fine". And I want meta-fields to go to root entry, because this is the way we got logs from other systems with logstash.
This PR is biased to my particular setup, so feel free to reject it, if it breaks someone else's setup. If it's really needed, I could add options to control entry format.