### PR TITLE
Update index-template-mapping.json

### DIFF
--- a/index-template-mapping.json
+++ b/index-template-mapping.json
@@ -38,8 +38,7 @@
         "fields": {
           "type": "object",
           "dynamic": true,
-          "index": "analyzed",
-          "path": "full"
+          "index": "analyzed"
         }
       }
     }


### PR DESCRIPTION
This template will have the consequences of : 

MapperParsingException[mapping [_default_]]; nested: MapperParsingException[Mapping definition for [fields] has unsupported parameters:  [path : full] [index : analyzed]];
	at org.elasticsearch.cluster.metadata.MetaDataCreateIndexService$2.execute(MetaDataCreateIndexService.java:359)
	at org.elasticsearch.cluster.service.InternalClusterService$UpdateTask.run(InternalClusterService.java:388)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:225)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:188)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: MapperParsingException[Mapping definition for [fields] has unsupported parameters:  [path : full] [index : analyzed]]
	at org.elasticsearch.index.mapper.DocumentMapperParser.checkNoRemainingFields(DocumentMapperParser.java:267)
	at org.elasticsearch.index.mapper.DocumentMapperParser.checkNoRemainingFields(DocumentMapperParser.java:261)
	at org.elasticsearch.index.mapper.object.ObjectMapper$TypeParser.parseProperties(ObjectMapper.java:317)
	at org.elasticsearch.index.mapper.object.ObjectMapper$TypeParser.parseObjectOrDocumentTypeProperties(ObjectMapper.java:228)
	at org.elasticsearch.index.mapper.object.RootObjectMapper$TypeParser.parse(RootObjectMapper.java:137)
	at org.elasticsearch.index.mapper.DocumentMapperParser.parse(DocumentMapperParser.java:211)
	at org.elasticsearch.index.mapper.DocumentMapperParser.parseCompressed(DocumentMapperParser.java:192)
	at org.elasticsearch.index.mapper.DocumentMapperParser.parseCompressed(DocumentMapperParser.java:177)
	at org.elasticsearch.index.mapper.MapperService.merge(MapperService.java:229)
	at org.elasticsearch.cluster.metadata.MetaDataCreateIndexService$2.execute(MetaDataCreateIndexService.java:356)
	... 6 more


I believe this is the same issue: https://www.coredump.id.au/inability-to-create-new-logstash-indexes-in-elasticsearch-2-0/