### PR TITLE
Fix require for index-template-mapping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
       - oracle-java8-set-default
 node_js:
   - "6"
+  - "8"
 jdk:
   - oraclejdk8
 env:

--- a/index.js
+++ b/index.js
@@ -195,4 +195,6 @@ Elasticsearch.prototype.ensureMappingTemplate = function ensureMappingTemplate(f
     });
 };
 
-module.exports = winston.transports.Elasticsearch = Elasticsearch;
+winston.transports.Elasticsearch = Elasticsearch;
+
+module.exports = winston.transports.Elasticsearch;

--- a/index.js
+++ b/index.js
@@ -168,8 +168,7 @@ Elasticsearch.prototype.ensureMappingTemplate = function ensureMappingTemplate(f
   const thiz = this;
   let mappingTemplate = thiz.options.mappingTemplate;
   if (mappingTemplate === null || typeof mappingTemplate === 'undefined') {
-    // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
-    mappingTemplate = require('index-template-mapping.json');
+    mappingTemplate = require('./index-template-mapping');
   }
   const tmplCheckMessage = {
     name: 'template_' + thiz.options.indexPrefix


### PR DESCRIPTION
winston-elasticsearch tries to load the JSON file `index-template-mapping.json` and it fails as `index-template-mapping.json`  is a file local to your module, not a dependency in node_modules.

As a result, Node.js 8 raises two warnings:
```
(node:109) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Cannot find module 'index-template-mapping.json'
(node:109) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will t
erminate the Node.js process with a non-zero exit code.
```

After some investigation, it appears that you did not write the correct instructions to require this file. It should be `require("./index-template-mapping")` instead of `require("index-template-mapping.json")`.

Hence, this pull request.