### PR TITLE
Added two possibilities to expand the index name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage/
 
 *.log
 *~
+.idea/

--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ make sure to provide a matching `mappingTemplate`.
 
 ## Transformer
 
-The transformer function allows to transform the log data structure as provided
-by winston into a structure more appropriate for indexing in ES.
+The transformer function allows mutation of log data as provided
+by winston into a shape more appropriate for indexing in Elasticsearch.
 
-The default transformer function's transformation is shown below.
+The default transformer generates a `@timestamp` and rolls any `meta`
+objects into an object called `fields`.
 
-Input:
+Input A:
 
 ```js
 {
@@ -102,7 +103,7 @@ Input:
 }
 ```
 
-Output:
+Output A:
 
 ```js
 {
@@ -117,7 +118,6 @@ Output:
 }
 ```
 
-The `@timestamp` is generated in the transformer.
 Note that in current logstash versions, the only "standard fields" are @timestamp and @version,
 anything else ist just free.
 
@@ -134,10 +134,10 @@ An example assuming default settings.
 ### Log Action
 
 ```js
-logger.info('Some message', <req meta data>);
+logger.info('Some message', {});
 ```
 
-where `req meta data` is a JSON object.
+Only JSON objects are logged from the `meta` field. Any non-object is ignored.
 
 ### Generated Message
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If multiple objects are provided as arguments, the contents are stringified.
 
 - `level` [`info`] Messages logged with a severity greater or equal to the given one are logged to ES; others are discarded.
 - `index` [none] the index to be used. This option is mutually exclusive with `indexPrefix`.
-- `indexPrefix` [`logs`] the prefix to use to generate the index name according to the pattern `<indexPrefix>-<indexSuffixPattern>`.
+- `indexPrefix` [`logs`] the prefix to use to generate the index name according to the pattern `<indexPrefix>-<indexInterfix>-<indexSuffixPattern>`. Can be string or function, returning the string to use.
 - `indexSuffixPattern` [`YYYY.MM.DD`] a [Moment.js](http://momentjs.com/) compatible date/ time pattern.
 - `messageType` [`log`] the type (path segment after the index path) under which the messages are stored under the index.
 - `transformer` [see below] a transformer function to transform logged data into a different message structure.
@@ -87,6 +87,25 @@ by winston into a shape more appropriate for indexing in Elasticsearch.
 
 The default transformer generates a `@timestamp` and rolls any `meta`
 objects into an object called `fields`.
+
+Params:
+
+- `logdata` An object with the data to log. Properties are:
+
+- `timestamp` [`new Date().toISOString()`] The timestamp of the log entry
+- `level` The log level of the entry
+- `message` The message for the log entry
+- `meta` The meta data for the log entry
+
+Returns: Object with the following properties 
+
+- `@timestamp` The timestamp of the log entry
+- `severity` The log level of the entry
+- `message` The message for the log entry
+- `fields` The meta data for the log entry
+- `indexInterfix` optional, the interfix of the index to use for this entry
+
+The default transformer function's transformation is shown below.
 
 Input A:
 

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -74,7 +74,7 @@ BulkWriter.prototype.flush = function flush() {
       res.items.forEach((item) => {
         if (item.index && item.index.error) {
           // eslint-disable-next-line no-console
-          console.error('Elasticsearch index error', item);
+          console.error('Elasticsearch index error', bulk);
         }
       });
     }

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -74,7 +74,7 @@ BulkWriter.prototype.flush = function flush() {
       res.items.forEach((item) => {
         if (item.index && item.index.error) {
           // eslint-disable-next-line no-console
-          console.error('Elasticsearch index error', item.index.error);
+          console.error('Elasticsearch index error', item);
         }
       });
     }
@@ -83,7 +83,7 @@ BulkWriter.prototype.flush = function flush() {
     thiz.bulk = bulk.concat(thiz.bulk);
     // eslint-disable-next-line no-console
     console.error(e);
-    debug('error occrrued', e);
+    debug('error occurred', e);
     this.stop();
     this.checkEsConnection();
   });

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -148,7 +148,7 @@ BulkWriter.prototype.ensureMappingTemplate = function ensureMappingTemplate(fulf
     mappingTemplate = JSON.parse(rawdata);
   }
   const tmplCheckMessage = {
-    name: 'template_' + thiz.options.indexPrefix
+    name: 'template_' + (typeof thiz.options.indexPrefix === 'function' ? thiz.options.indexPrefix() : thiz.options.indexPrefix)
   };
   thiz.client.indices.getTemplate(tmplCheckMessage).then(
     (res) => {
@@ -157,7 +157,7 @@ BulkWriter.prototype.ensureMappingTemplate = function ensureMappingTemplate(fulf
     (res) => {
       if (res.status && res.status === 404) {
         const tmplMessage = {
-          name: 'template_' + thiz.options.indexPrefix,
+          name: 'template_' + (typeof thiz.options.indexPrefix === 'function' ? thiz.options.indexPrefix() : thiz.options.indexPrefix),
           create: true,
           body: mappingTemplate
         };

--- a/index.js
+++ b/index.js
@@ -88,7 +88,6 @@ module.exports = class Elasticsearch extends Transport {
     if (entry.indexInterfix !== undefined) {
       index = this.getIndexName(this.opts, entry.indexInterfix);
       delete entry.indexInterfix;
-      console.log(entry);
     }
     this.bulkWriter.append(
       index,

--- a/index.js
+++ b/index.js
@@ -14,16 +14,13 @@ module.exports = class Elasticsearch extends Transport {
     this.name = 'elasticsearch';
 
     this.opts = opts || {};
-    if (!opts.timestamp) {
-      this.opts.timestamp = function timestamp() { return new Date().toISOString(); };
-    }
     // Enforce context
     // if (!(this instanceof Elasticsearch)) {
     //   return new Elasticsearch(opts);
     // }
 
     // Set defaults
-    const defaults = {
+    _.defaults(opts, {
       level: 'info',
       index: null,
       indexPrefix: 'logs',
@@ -35,14 +32,13 @@ module.exports = class Elasticsearch extends Transport {
       waitForActiveShards: 1,
       handleExceptions: false,
       pipeline: null
-    };
-    _.defaults(opts, defaults);
+    });
 
     // Use given client or create one
     if (opts.client) {
       this.client = opts.client;
     } else {
-      const defaultClientOpts = {
+      _.defaults(opts, {
         clientOpts: {
           log: [
             {
@@ -51,8 +47,7 @@ module.exports = class Elasticsearch extends Transport {
             }
           ]
         }
-      };
-      _.defaults(opts, defaultClientOpts);
+      });
 
       // Create a new ES client
       // http://localhost:9200 is the default of the client already
@@ -76,7 +71,8 @@ module.exports = class Elasticsearch extends Transport {
   }
 
   log(info, callback) {
-    const { level, message, ...meta } = info;
+    const { level, message } = info;
+    const meta = Object.assign({}, _.omit(info, ['level', 'message']));
     setImmediate(() => {
       this.emit('logged', level);
     });
@@ -97,24 +93,6 @@ module.exports = class Elasticsearch extends Transport {
     callback();
   }
 
-  query(options, callback) {
-    // const opts = this.normalizeQuery(options);
-    const index = this.getIndexName(this.opts);
-    const query = {
-      index,
-      // q
-    };
-    return this.client.search(query);
-  }
-
-  search(q) {
-    const index = this.getIndexName(this.opts);
-    const query = {
-      index,
-      q
-    };
-    return this.client.search(query);
-  }
 
   getIndexName(opts) {
     this.test = 'test';

--- a/index.js
+++ b/index.js
@@ -84,8 +84,14 @@ module.exports = class Elasticsearch extends Transport {
     };
 
     const entry = this.opts.transformer(logData);
+    let index = this.getIndexName(this.opts);
+    if (entry.index !== undefined) {
+      index = entry.index;
+      delete entry.index;
+      console.log(entry);
+    }
     this.bulkWriter.append(
-      this.getIndexName(this.opts),
+      index,
       this.opts.messageType,
       entry
     );
@@ -98,6 +104,7 @@ module.exports = class Elasticsearch extends Transport {
     this.test = 'test';
     let indexName = opts.index;
     if (indexName === null) {
+      // eslint-disable-next-line prefer-destructuring
       let indexPrefix = opts.indexPrefix;
       if (typeof indexPrefix === 'function') {
         // eslint-disable-next-line prefer-destructuring

--- a/index.js
+++ b/index.js
@@ -98,9 +98,14 @@ module.exports = class Elasticsearch extends Transport {
     this.test = 'test';
     let indexName = opts.index;
     if (indexName === null) {
+      let indexPrefix = opts.indexPrefix;
+      if (typeof indexPrefix === 'function') {
+        // eslint-disable-next-line prefer-destructuring
+        indexPrefix = opts.index();
+      }
       const now = moment();
       const dateString = now.format(opts.indexSuffixPattern);
-      indexName = opts.indexPrefix + '-' + dateString;
+      indexName = indexPrefix + '-' + dateString;
     }
     return indexName;
   }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const Transport = require('winston-transport');
 const moment = require('moment');
 const _ = require('lodash');
 const elasticsearch = require('elasticsearch');
-const { LEVEL, SPLAT } = require('triple-beam');
 const defaultTransformer = require('./transformer');
 const BulkWriter = require('./bulk_writer');
 
@@ -77,17 +76,7 @@ module.exports = class Elasticsearch extends Transport {
   }
 
   log(info, callback) {
-    const level = info[LEVEL];
-    const { message } = info;
-    let meta = info[SPLAT];
-    if (meta !== undefined) {
-      // eslint-disable-next-line prefer-destructuring
-      meta = meta[0];
-    } else {
-      meta = info;
-      delete meta.message;
-      delete meta.level;
-    }
+    const { level, message, ...meta } = info;
     setImmediate(() => {
       this.emit('logged', level);
     });
@@ -96,7 +85,6 @@ module.exports = class Elasticsearch extends Transport {
       message,
       level,
       meta,
-      // timestamp: this.opts.timestamp()
     };
 
     const entry = this.opts.transformer(logData);

--- a/index.js
+++ b/index.js
@@ -85,9 +85,9 @@ module.exports = class Elasticsearch extends Transport {
 
     const entry = this.opts.transformer(logData);
     let index = this.getIndexName(this.opts);
-    if (entry.index !== undefined) {
-      index = entry.index;
-      delete entry.index;
+    if (entry.indexInterfix !== undefined) {
+      index = this.getIndexName(this.opts, entry.indexInterfix);
+      delete entry.indexInterfix;
       console.log(entry);
     }
     this.bulkWriter.append(
@@ -100,7 +100,7 @@ module.exports = class Elasticsearch extends Transport {
   }
 
 
-  getIndexName(opts) {
+  getIndexName(opts, indexInterfix) {
     this.test = 'test';
     let indexName = opts.index;
     if (indexName === null) {
@@ -112,7 +112,7 @@ module.exports = class Elasticsearch extends Transport {
       }
       const now = moment();
       const dateString = now.format(opts.indexSuffixPattern);
-      indexName = indexPrefix + '-' + dateString;
+      indexName = indexPrefix + (indexInterfix !== undefined ? '-' + indexInterfix : '') + '-' + dateString;
     }
     return indexName;
   }

--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ module.exports = class Elasticsearch extends Transport {
       let indexPrefix = opts.indexPrefix;
       if (typeof indexPrefix === 'function') {
         // eslint-disable-next-line prefer-destructuring
-        indexPrefix = opts.index();
+        indexPrefix = opts.indexPrefix();
       }
       const now = moment();
       const dateString = now.format(opts.indexSuffixPattern);

--- a/test/request_logentry_1.json
+++ b/test/request_logentry_1.json
@@ -1,5 +1,5 @@
 {
-  "message": "logmessage1",
+  "message": "logmessage",
   "level": "info",
   "meta": {
     "method": "GET",

--- a/test/test.js
+++ b/test/test.js
@@ -27,17 +27,15 @@ function NullLogger(config) {
 function createLogger() {
   return winston.createLogger({
     transports: [
-      new (winston.transports.Elasticsearch)({
-        flushInterval: 10,
+      new winston.transports.Elasticsearch({
+        flushInterval: 1,
         clientOpts: {
           log: NullLogger,
         }
-      })
-    ]
+      })]
   });
 }
 
-describe('winston-elasticsearch:', function () {
   describe('the default transformer', function () {
     it('should transform log data from winston into a logstash like structure', function (done) {
       var transformed = defaultTransformer({
@@ -69,7 +67,9 @@ describe('winston-elasticsearch:', function () {
 
     it('should log simple message to Elasticsearch', function (done) {
       this.timeout(8000);
-      logger.log(logMessage.level, logMessage.message);
+      logger = createLogger();
+
+      logger.log(logMessage.level, `${logMessage.message}1`);
       logger.on('finish', () => {
         done();
       });
@@ -79,11 +79,14 @@ describe('winston-elasticsearch:', function () {
       logger.end();
     });
 
-    it('should log splat free message to Elasticsearch', function (done) {
+    it('should log with or without metadata', function (done) {
       this.timeout(8000);
       logger = createLogger();
 
-      logger.info({ message: 'Test', foo: 'bar' });
+      logger.info('test test');
+      logger.info('test test', 'hello world');
+      logger.info({ message: 'test test', foo: 'bar' });
+      logger.log(logMessage.level, `${logMessage.message}2`, logMessage.meta);
       logger.on('finish', () => {
         done();
       });
@@ -93,24 +96,7 @@ describe('winston-elasticsearch:', function () {
       logger.end();
     });
 
-    it('should log message with meta data to Elasticsearch', function (done) {
-      this.timeout(8000);
-      logger = createLogger();
-
-      logMessage.message = 'logmessage2';
-      logger.log(logMessage.level, logMessage.message, logMessage.meta);
-      logger.on('finish', () => {
-        done();
-      });
-      logger.on('error', (err) => {
-        should.not.exist(err);
-      });
-
-      setTimeout(function(){
-        logger.end();
-      }, 3000);
-    });
-/*
+    /*
     describe('the logged message', function () {
       it('should be found in the index', function (done) {
         var client = new elasticsearch.Client({
@@ -131,8 +117,6 @@ describe('winston-elasticsearch:', function () {
     });
 */
   });
-
-  var defectiveLogger = null;
 
   // describe('a defective log transport', function () {
   //   it('emits an error', function (done) {
@@ -172,4 +156,3 @@ describe('winston-elasticsearch:', function () {
       });
     });
   */
-  });


### PR DESCRIPTION
In a recent project I had the challenge to enable a better logging. Therefore I added two options to winston-elasticsearch:

Option 1: Enable to use a function for option property indexPrefix to use a variable name for the log.
Option 2: Introduced the indexInterfix property to be used in the log transformer to create individual logs for each log entry like prefix-interfix-suffix.