### PR TITLE
splat metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ make sure to provide a matching `mappingTemplate`.
 
 ## Transformer
 
-The transformer function allows to transform the log data structure as provided
-by winston into a structure more appropriate for indexing in ES.
+The transformer function allows mutation of log data as provided
+by winston into a shape more appropriate for indexing in Elasticsearch.
 
-The default transformer function's transformation is shown below.
+The default transformer generates a `@timestamp` and rolls any `meta`
+objects into an object called `fields`.
 
-Input:
+Input A:
 
 ```js
 {
@@ -102,7 +103,7 @@ Input:
 }
 ```
 
-Output:
+Output A:
 
 ```js
 {
@@ -117,7 +118,6 @@ Output:
 }
 ```
 
-The `@timestamp` is generated in the transformer.
 Note that in current logstash versions, the only "standard fields" are @timestamp and @version,
 anything else ist just free.
 
@@ -134,10 +134,10 @@ An example assuming default settings.
 ### Log Action
 
 ```js
-logger.info('Some message', <req meta data>);
+logger.info('Some message', {});
 ```
 
-where `req meta data` is a JSON object.
+Only JSON objects are logged from the `meta` field. Any non-object is ignored.
 
 ### Generated Message
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ const Transport = require('winston-transport');
 const moment = require('moment');
 const _ = require('lodash');
 const elasticsearch = require('elasticsearch');
-const { LEVEL, SPLAT } = require('triple-beam');
 const defaultTransformer = require('./transformer');
 const BulkWriter = require('./bulk_writer');
 
@@ -77,17 +76,7 @@ module.exports = class Elasticsearch extends Transport {
   }
 
   log(info, callback) {
-    const level = info[LEVEL];
-    const { message } = info;
-    let meta = info[SPLAT];
-    if (meta !== undefined) {
-      // eslint-disable-next-line prefer-destructuring
-      meta = meta[0];
-    } else {
-      meta = info;
-      delete meta.message;
-      delete meta.level;
-    }
+    const { level, message, ...meta } = info;
     setImmediate(() => {
       this.emit('logged', level);
     });
@@ -96,7 +85,6 @@ module.exports = class Elasticsearch extends Transport {
       message,
       level,
       meta,
-      // timestamp: this.opts.timestamp()
     };
 
     const entry = this.opts.transformer(logData);

--- a/test/request_logentry_1.json
+++ b/test/request_logentry_1.json
@@ -1,5 +1,5 @@
 {
-  "message": "logmessage1",
+  "message": "logmessage",
   "level": "info",
   "meta": {
     "method": "GET",

--- a/test/test.js
+++ b/test/test.js
@@ -27,17 +27,15 @@ function NullLogger(config) {
 function createLogger() {
   return winston.createLogger({
     transports: [
-      new (winston.transports.Elasticsearch)({
-        flushInterval: 10,
+      new winston.transports.Elasticsearch({
+        flushInterval: 1,
         clientOpts: {
           log: NullLogger,
         }
-      })
-    ]
+      })]
   });
 }
 
-describe('winston-elasticsearch:', function () {
   describe('the default transformer', function () {
     it('should transform log data from winston into a logstash like structure', function (done) {
       var transformed = defaultTransformer({
@@ -69,7 +67,9 @@ describe('winston-elasticsearch:', function () {
 
     it('should log simple message to Elasticsearch', function (done) {
       this.timeout(8000);
-      logger.log(logMessage.level, logMessage.message);
+      logger = createLogger();
+
+      logger.log(logMessage.level, `${logMessage.message}1`);
       logger.on('finish', () => {
         done();
       });
@@ -79,11 +79,14 @@ describe('winston-elasticsearch:', function () {
       logger.end();
     });
 
-    it('should log splat free message to Elasticsearch', function (done) {
+    it('should log with or without metadata', function (done) {
       this.timeout(8000);
       logger = createLogger();
 
-      logger.info({ message: 'Test', foo: 'bar' });
+      logger.info('test test');
+      logger.info('test test', 'hello world');
+      logger.info({ message: 'test test', foo: 'bar' });
+      logger.log(logMessage.level, `${logMessage.message}2`, logMessage.meta);
       logger.on('finish', () => {
         done();
       });
@@ -93,24 +96,7 @@ describe('winston-elasticsearch:', function () {
       logger.end();
     });
 
-    it('should log message with meta data to Elasticsearch', function (done) {
-      this.timeout(8000);
-      logger = createLogger();
-
-      logMessage.message = 'logmessage2';
-      logger.log(logMessage.level, logMessage.message, logMessage.meta);
-      logger.on('finish', () => {
-        done();
-      });
-      logger.on('error', (err) => {
-        should.not.exist(err);
-      });
-
-      setTimeout(function(){
-        logger.end();
-      }, 3000);
-    });
-/*
+    /*
     describe('the logged message', function () {
       it('should be found in the index', function (done) {
         var client = new elasticsearch.Client({
@@ -131,8 +117,6 @@ describe('winston-elasticsearch:', function () {
     });
 */
   });
-
-  var defectiveLogger = null;
 
   // describe('a defective log transport', function () {
   //   it('emits an error', function (done) {
@@ -172,4 +156,3 @@ describe('winston-elasticsearch:', function () {
       });
     });
   */
-  });

--- a/transformer.js
+++ b/transformer.js
@@ -8,12 +8,16 @@
  @param {Object} logData.meta - the log meta data (JSON object)
  @returns {Object} transformed message
  */
+const isObject = (obj) => { return obj instanceof Object; };
+
 const transformer = function transformer(logData) {
   const transformed = {};
   transformed['@timestamp'] = logData.timestamp ? logData.timestamp : new Date().toISOString();
   transformed.message = logData.message;
   transformed.severity = logData.level;
-  transformed.fields = logData.meta;
+  transformed.fields = (isObject(logData.meta) && logData.meta)
+    || (logData.meta && { meta: logData.meta });
+  console.log(JSON.stringify(transformed));
   return transformed;
 };
 

--- a/transformer.js
+++ b/transformer.js
@@ -8,16 +8,12 @@
  @param {Object} logData.meta - the log meta data (JSON object)
  @returns {Object} transformed message
  */
-const isObject = (obj) => { return obj instanceof Object; };
-
 const transformer = function transformer(logData) {
   const transformed = {};
   transformed['@timestamp'] = logData.timestamp ? logData.timestamp : new Date().toISOString();
   transformed.message = logData.message;
   transformed.severity = logData.level;
-  transformed.fields = (isObject(logData.meta) && logData.meta)
-    || (logData.meta && { meta: logData.meta });
-  console.log(JSON.stringify(transformed));
+  transformed.fields = logData.meta;
   return transformed;
 };
 


### PR DESCRIPTION
`winston` allows logging loose metadata that is not just a JSON object. However, due to the constraints of Elasticsearch's `dynamic` field for object datatypes, `winston-elasticsearch` has to enforce (at least for the default Elasticsearch mapping template) that `meta` is an object. Currently it does not. This leads to lost logs if just a single log has a concrete value rather than an object in metadata, because Elasticsearch will error out the bulk request.

This PR just splats into a meta object which gets passed to the transformer.