### PR TITLE
Fire callback to inform winston about log delivery in time

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -63,9 +63,13 @@ BulkWriter.prototype.flush = function flush() {
   }
   const bulk = this.bulk.concat();
   this.bulk = [];
-  debug('going to write', bulk);
+  const body = [];
+  bulk.forEach(({ index, type, doc }) => {
+    body.push({ index: { _index: index, _type: type, pipeline: this.pipeline } }, doc);
+  });
+  debug('going to write', body);
   return this.client.bulk({
-    body: bulk,
+    body,
     waitForActiveShards: this.waitForActiveShards,
     timeout: this.interval + 'ms',
     type: this.type
@@ -91,11 +95,8 @@ BulkWriter.prototype.flush = function flush() {
 
 BulkWriter.prototype.append = function append(index, type, doc) {
   this.bulk.push({
-    index: {
-      _index: index, _type: type, pipeline: this.pipeline
-    }
+    index, type, doc
   });
-  this.bulk.push(doc);
 };
 
 BulkWriter.prototype.checkEsConnection = function checkEsConnection() {

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -82,6 +82,7 @@ BulkWriter.prototype.flush = function flush() {
         }
       });
     }
+    bulk.forEach(({ callback }) => callback());
   }).catch((e) => { // prevent [DEP0018] DeprecationWarning
     // rollback this.bulk array
     thiz.bulk = bulk.concat(thiz.bulk);
@@ -93,9 +94,9 @@ BulkWriter.prototype.flush = function flush() {
   });
 };
 
-BulkWriter.prototype.append = function append(index, type, doc) {
+BulkWriter.prototype.append = function append(index, type, doc, callback) {
   this.bulk.push({
-    index, type, doc
+    index, type, doc, callback
   });
 };
 

--- a/index.js
+++ b/index.js
@@ -92,10 +92,9 @@ module.exports = class Elasticsearch extends Transport {
     this.bulkWriter.append(
       index,
       this.opts.messageType,
-      entry
+      entry,
+      callback
     );
-
-    callback();
   }
 
 


### PR DESCRIPTION
Hey,

```
process.on('uncaughtException', err => {
  logger.error('uncaughtException', err, {stack: err.stack});
  logger.on('finish', () => process.exit(1));
  logger.end();
});
```

In this code in case of uncaught exception we could lose logs, because `winston-elasticsearch` transport calls callback inside `log()` instantly, but it supposed to do it after log delivery (or an error, but it more complex ;) )