### PR TITLE
Issue: flush called twice after each interval instead of once

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -19,8 +19,6 @@ const BulkWriter = function BulkWriter(client, options) {
 
 BulkWriter.prototype.start = function start() {
   this.checkEsConnection();
-  this.running = true;
-  this.tick();
   debug('started');
 };
 


### PR DESCRIPTION
Issue: flush called twice after each interval instead of once

Reason: Two ticks are getting scheduled

Solution: No need to call tick at the start since this.checkEsConnection()
          is already doing that