### PR TITLE
The callback of log(info, callback) was used in a wrong manner

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -65,10 +65,10 @@ BulkWriter.prototype.flush = function flush() {
     body.push({ index: { _index: index, _type: type, pipeline: this.pipeline } }, doc);
   });
   debug('bulk writer is going to write', body);
-  return this.write(body, bulk);
+  return this.write(body);
 };
 
-BulkWriter.prototype.append = function append(index, type, doc, callback) {
+BulkWriter.prototype.append = function append(index, type, doc) {
   if (this.options.buffering === true) {
     if (typeof this.options.bufferLimit === 'number' && this.bulk.length >= this.options.bufferLimit) {
       debug('message discarded because buffer limit exceeded');
@@ -76,15 +76,14 @@ BulkWriter.prototype.append = function append(index, type, doc, callback) {
       return;
     }
     this.bulk.push({
-      index, type, doc, callback
+      index, type, doc
     });
   } else {
-    this.write([{ index: { _index: index, _type: type, pipeline: this.pipeline } }, doc],
-      [{ callback }]);
+    this.write([{ index: { _index: index, _type: type, pipeline: this.pipeline } }, doc]);
   }
 };
 
-BulkWriter.prototype.write = function write(body, bulk) {
+BulkWriter.prototype.write = function write(body) {
   const thiz = this;
   //console.log('TEST00', body);
   return this.client.bulk({
@@ -100,11 +99,6 @@ BulkWriter.prototype.write = function write(body, bulk) {
           console.error('Elasticsearch index error', item.index);
         }
       });
-    }
-    //console.log('TEST11');
-    if (bulk) {
-      //console.log('TEST22');
-      bulk.forEach(({ callback }) => callback());
     }
   }).catch((e) => { // prevent [DEP0018] DeprecationWarning
     // rollback this.bulk array

--- a/index.js
+++ b/index.js
@@ -95,9 +95,10 @@ module.exports = class Elasticsearch extends Transport {
     this.bulkWriter.append(
       index,
       this.opts.messageType,
-      entry,
-      callback
+      entry
     );
+
+    callback();
   }
 
   getIndexName(opts, indexInterfix) {


### PR DESCRIPTION
de6e51f37a20b683b76f71ae10038a86736e1058 introduced the wrong use of callback in `log(info, callback)` which lead to the following issues:

- the @timestamp is wrong because the transformer is only called every 2 seconds by default (flushInterval for bulk write)
- other transports are stopped for flushInterval because the callback isn't called

For further information about correct use of the callback please read https://github.com/winstonjs/winston/blob/master/lib/winston/logger.js

For tests please clone https://github.com/litti/test-winston-elasticsearch and change the version of winston-elasticsearch in package.json to 0.7.3, 0.7.4 and git+https://github.com/litti/winston-elasticsearch.git. After each change run `node app.js`. Watch the logs in console and the timestamps in your elastichsearch log.