### PR TITLE
Get timestamp from info

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ module.exports = class Elasticsearch extends Transport {
   }
 
   log(info, callback) {
-    const { level, message } = info;
+    const { level, message, timestamp } = info;
     const meta = Object.assign({}, _.omit(info, ['level', 'message']));
     setImmediate(() => {
       this.emit('logged', level);
@@ -83,6 +83,7 @@ module.exports = class Elasticsearch extends Transport {
     const logData = {
       message,
       level,
+      timestamp,
       meta,
     };
 


### PR DESCRIPTION
## issue 
We are NOT able to pass the **actual timestamp** into transformer, always the **postponed timestamp** (`new Date().toISOString()`) gets logged. This leads to **wrong/delayed** timestamp log.

```js
  log(info, callback) {
    const { level, message } = info;
    const meta = Object.assign({}, _.omit(info, ['level', 'message']));
    setImmediate(() => {
      this.emit('logged', level);
    });

    const logData = {
      message,
      level,
      meta,
    };

    const entry = this.opts.transformer(logData); // logData never has `timestamp`
    ....
  }
```

```js
const transformer = function transformer(logData) {
  const transformed = {};
  transformed['@timestamp'] = logData.timestamp ? logData.timestamp : new Date().toISOString();
  transformed.message = logData.message;
  transformed.severity = logData.level;
  transformed.fields = logData.meta;
  return transformed;
};
```

## Solution
By passing `timestamp` to logData