### PR TITLE
properly updated buffer(bulk array) while rollback.

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -105,7 +105,7 @@ BulkWriter.prototype.write = function write(body) {
     // rollback this.bulk array
     const _body = [];
     for (let i = 0; i < body.length; i += 2) {
-      _body.push({index: body[i].index._index, type: body[i].index.type, doc: body[i+1]});
+      _body.push({index: body[i].index._index, type: body[i].index._type, doc: body[i+1]});
     }
     const lenSum = thiz.bulk.length + _body.length;
     if (thiz.options.bufferLimit && (lenSum >= thiz.options.bufferLimit)) {

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -103,11 +103,15 @@ BulkWriter.prototype.write = function write(body) {
     }
   }).catch((e) => { // prevent [DEP0018] DeprecationWarning
     // rollback this.bulk array
-    const lenSum = thiz.bulk.length + body.length;
+    const _body = [];
+    for (let i = 0; i < body.length; i += 2) {
+      _body.push({index: body[i].index._index, type: body[i].index.type, doc: body[i+1]});
+    }
+    const lenSum = thiz.bulk.length + _body.length;
     if (thiz.options.bufferLimit && (lenSum >= thiz.options.bufferLimit)) {
-      thiz.bulk = body.concat(thiz.bulk.slice(0, thiz.options.bufferLimit - body.length));
+      thiz.bulk = _body.concat(thiz.bulk.slice(0, thiz.options.bufferLimit - _body.length));
     } else {
-      thiz.bulk = body.concat(thiz.bulk);
+      thiz.bulk = _body.concat(thiz.bulk);
     }
     // eslint-disable-next-line no-console
     thiz.transport.emit('error', e);


### PR DESCRIPTION
Each object of buffer is expected to have 3 keys: index, type and doc.
While creating body each object of buffer is broken into 2 object, so while rollback merged these 2 object back into one before adding into buffer.

This pull request also fixes https://github.com/vanthome/winston-elasticsearch/issues/89