### PR TITLE
Refine the type of waitForActiveShards field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare module 'winston-elasticsearch' {
     mappingTemplate?: { [key: string]: any };
     ensureMappingTemplate?: boolean;
     flushInterval?: number;
-    waitForActiveShards?: number;
+    waitForActiveShards?: number | 'all';
     handleExceptions?: boolean;
     pipeline?: string;
     client?: Client;


### PR DESCRIPTION
In all three API references ([5.x](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/5.x/api-reference.html#_bulk), [6.x](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/6.x/api-reference.html#_bulk), [7.x](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/7.x/api-reference.html#_bulk)) it is said:

![image](https://user-images.githubusercontent.com/4586392/66599773-b67c1c00-ebac-11e9-8699-7f8efefa85cf.png)

So this PR refines the type.