### PR TITLE
Don't pass redundant "type" field

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -90,7 +90,6 @@ BulkWriter.prototype.write = function write(body) {
     body,
     waitForActiveShards: this.waitForActiveShards,
     timeout: this.interval + 'ms',
-    type: this.type
   }).then((res) => {
     if (res.errors && res.items) {
       res.items.forEach((item) => {


### PR DESCRIPTION
1. Let's look at the following code:

   ```js
   BulkWriter.prototype.write = function write(body) {
     const thiz = this;
     return this.client.bulk({
       // ...
       type: this.type,
     }).then(...)
   ```

   `this.type === undefined`, cause `this` points to the `write` [function context](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#Function_context). So you should be very careful with it.

2. The other thing to keep in mind is that according to [the reference](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/7.x/api-reference.html#_bulk) `type` field can be passed to API. But if you check out the source code of elastic-search js client, [bulk.js#L67](https://github.com/elastic/elasticsearch-js/blob/5263c56fdaff093894760c754d67f02249683c78/api/api/bulk.js#L67), you will see that `type` can be passed only with `index` field.

So there are two ways: either just don't pass `type` to `_bulk` handler, or send `_doc` + index as default values. In this PR I implemented the first. If you think otherwise, I would like also to do it myself.
