### PR TITLE
Fix references to elasticsearch package in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ If multiple objects are provided as arguments, the contents are stringified.
 - `ensureMappingTemplate` [`true`] If set to `true`, the given `mappingTemplate` is checked/ uploaded to ES when the module is sending the fist log message to make sure the log messages are mapped in a sensible manner.
 - `mappingTemplate` [see file `index-template-mapping.json` file] the mapping template to be ensured as parsed JSON.
 - `flushInterval` [`2000`] distance between bulk writes in ms.
-- `client` An [elasticsearch client](https://www.npmjs.com/package/elasticsearch) instance. If given, all following options are ignored.
-- `clientOpts` An object hash passed to the ES client. See [its docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html) for supported options.
+- `client` An [elasticsearch client](https://www.npmjs.com/package/@elastic/elasticsearch) instance. If given, all following options are ignored.
+- `clientOpts` An object hash passed to the ES client. See [its docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-configuration.html) for supported options.
 - `waitForActiveShards` [`1`] Sets the number of shard copies that must be active before proceeding with the bulk operation.
 - `pipeline` [none] Sets the pipeline id to pre-process incoming documents with. See [the bulk API docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-bulk).
 - `buffering` [true] Boolean flag to enable or disable messages buffering. The `bufferLimit` option is ignored if set to `false`.


### PR DESCRIPTION
README wasn't updated when `elasticsearch` was deprecated in favor of `@elastic/elasticsearch` and this package moved to it. The old URL linking to docs for clientOpts 404s on the elastic website (https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html vs https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-configuration.html) 