### PR TITLE
ES client has new return format

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
       "ignoreReadBeforeAssign": true
     }],
     "space-before-function-paren": 0,
+    "prefer-object-spread": 0,
     "strict": 0
   },
   "plugins": [

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -105,7 +105,7 @@ BulkWriter.prototype.write = function write(body) {
     // rollback this.bulk array
     const _body = [];
     for (let i = 0; i < body.length; i += 2) {
-      _body.push({index: body[i].index._index, type: body[i].index._type, doc: body[i+1]});
+      _body.push({ index: body[i].index._index, type: body[i].index._type, doc: body[i + 1] });
     }
     const lenSum = thiz.bulk.length + _body.length;
     if (thiz.options.bufferLimit && (lenSum >= thiz.options.bufferLimit)) {

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -1,3 +1,5 @@
+/* eslint no-underscore-dangle: ["error", { "allow": ["_index", "_type"] }] */
+
 const fs = require('fs');
 const path = require('path');
 const Promise = require('promise');

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -95,8 +95,8 @@ BulkWriter.prototype.write = function write(body) {
     if (res.errors && res.items) {
       res.items.forEach((item) => {
         if (item.index && item.index.error) {
-          // eslint-disable-next-line no-console
           thiz.transport.emit('error', item.index.error);
+          // eslint-disable-next-line no-console
           console.error('Elasticsearch index error', item.index);
         }
       });
@@ -113,8 +113,8 @@ BulkWriter.prototype.write = function write(body) {
     } else {
       thiz.bulk = _body.concat(thiz.bulk);
     }
-    // eslint-disable-next-line no-console
     thiz.transport.emit('error', e);
+    // eslint-disable-next-line no-console
     console.error(e);
 
     debug('error occurred', e);

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -90,7 +90,8 @@ BulkWriter.prototype.write = function write(body) {
     body,
     waitForActiveShards: this.waitForActiveShards,
     timeout: this.interval + 'ms',
-  }).then((res) => {
+  }).then((response) => {
+    const res = response.body;
     if (res.errors && res.items) {
       res.items.forEach((item) => {
         if (item.index && item.index.error) {
@@ -186,7 +187,7 @@ BulkWriter.prototype.ensureMappingTemplate = function ensureMappingTemplate(fulf
         };
         thiz.client.indices.putTemplate(tmplMessage).then(
           (res1) => {
-            fulfill(res1);
+            fulfill(res1.body);
           },
           (err1) => {
             thiz.transport.emit('error', err1);
@@ -194,7 +195,7 @@ BulkWriter.prototype.ensureMappingTemplate = function ensureMappingTemplate(fulf
           }
         );
       } else {
-        fulfill(res);
+        fulfill(res.body);
       }
     },
     (res) => {

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -105,15 +105,15 @@ BulkWriter.prototype.write = function write(body) {
     }
   }).catch((e) => { // prevent [DEP0018] DeprecationWarning
     // rollback this.bulk array
-    const _body = [];
+    const newBody = [];
     for (let i = 0; i < body.length; i += 2) {
-      _body.push({ index: body[i].index._index, type: body[i].index._type, doc: body[i + 1] });
+      newBody.push({ index: body[i].index._index, type: body[i].index._type, doc: body[i + 1] });
     }
-    const lenSum = thiz.bulk.length + _body.length;
+    const lenSum = thiz.bulk.length + newBody.length;
     if (thiz.options.bufferLimit && (lenSum >= thiz.options.bufferLimit)) {
-      thiz.bulk = _body.concat(thiz.bulk.slice(0, thiz.options.bufferLimit - _body.length));
+      thiz.bulk = newBody.concat(thiz.bulk.slice(0, thiz.options.bufferLimit - newBody.length));
     } else {
-      thiz.bulk = _body.concat(thiz.bulk);
+      thiz.bulk = newBody.concat(thiz.bulk);
     }
     thiz.transport.emit('error', e);
     // eslint-disable-next-line no-console


### PR DESCRIPTION
ElasticSearch official client now return API response at `body` property among meta-information like `statusCode` or `headers`.

https://www.npmjs.com/package/@elastic/elasticsearch#quick-start

Need to correctly handle that change.