### PR TITLE
- When this.client.bulk is called, response.body returns an empty object

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -94,7 +94,7 @@ BulkWriter.prototype.write = function write(body) {
     timeout: this.interval + 'ms',
   }).then((response) => {
     const res = response.body;
-    if (res.errors && res.items) {
+    if (res && res.errors && res.items) {
       res.items.forEach((item) => {
         if (item.index && item.index.error) {
           thiz.transport.emit('error', item.index.error);


### PR DESCRIPTION
- This could happen when the schema change, adding or removing fields.
- The fix just verifies and prevent the response.body exist before be used.
- No side effects found since this is a tiny fix.