### PR TITLE
fix typescript error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'winston-elasticsearch' {
   import { Client, ClientOptions, ApiResponse } from '@elastic/elasticsearch';
-  import TransportStream from 'winston-transport';
+  import TransportStream = require('winston-transport');
 
   export interface LogData {
     message: any;


### PR DESCRIPTION
Updated part of `index.d.ts` which was causing problems with typescript - `ElasticsearchTransport` not being seen by ts as type of TransportStream