### PR TITLE
Instrument logs with elastic-apm traces

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,14 @@ module.exports = class Elasticsearch extends Transport {
       index = this.getIndexName(this.opts, entry.indexInterfix);
       delete entry.indexInterfix;
     }
+
+    if (this.opts.apm) {
+      const apm = this.opts.apm.currentTraceIds;
+      if (apm['transaction.id']) entry.transaction = { id: apm['transaction.id'], ...entry.transaction };
+      if (apm['trace.id']) entry.trace = { id: apm['trace.id'], ...entry.transaction };
+      if (apm['span.id']) entry.span = { id: apm['span.id'], ...entry.transaction };
+    }
+
     this.bulkWriter.append(
       index,
       this.opts.messageType,

--- a/transformer.js
+++ b/transformer.js
@@ -14,6 +14,11 @@ const transformer = function transformer(logData) {
   transformed.message = logData.message;
   transformed.severity = logData.level;
   transformed.fields = logData.meta;
+
+  if (logData.meta['transaction.id']) transformed.transaction = { id: logData.meta['transaction.id'] };
+  if (logData.meta['trace.id']) transformed.trace = { id: logData.meta['trace.id'] };
+  if (logData.meta['span.id']) transformed.span = { id: logData.meta['span.id'] };
+
   return transformed;
 };
 


### PR DESCRIPTION
- update the readme including how to use
- update the transformer so one can inject own traces
- update the constructor with reference to the apm module
- update the log function to use the client or the user's own apm traces

---

I know this was not an open issue though I needed this feature.

APM logs lets you know how long a functions takes, as well as its subsequent calls (e.g. database):
![apm](https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt335dee0ea0c58956/5dcb109412ad890272475f51/screenshot-apm-distributed-tracing.jpg "Example of apm tracing")
[source](https://www.elastic.co/apm)

With this feature, one can use kibana [logs apm integration](https://www.elastic.co/guide/en/kibana/current/xpack-logs-using.html#logs-integrations) to get more insight from their logs