### PR TITLE
mapping template returns error with es 6.8.0

### DIFF
--- a/index-template-mapping.json
+++ b/index-template-mapping.json
@@ -1,5 +1,5 @@
 {
-  "index_patterns": "logs-*",
+  "index_patterns": ["logs-*"],
   "settings": {
     "number_of_shards": 1,
     "number_of_replicas": 0,
@@ -8,15 +8,17 @@
     }
   },
   "mappings": {
+    "index": {
     "_source": { "enabled": true },
     "properties": {
       "@timestamp": { "type": "date" },
       "@version": { "type": "keyword" },
-      "message": { "type": "text", "index": true },
-      "severity": { "type": "keyword", "index": true },
+      "message": { "type": "text" },
+      "severity": { "type": "keyword" },
       "fields": {
         "dynamic": true,
         "properties": { }
+        }
       }
     }
   }


### PR DESCRIPTION
This PR try to fix the error I had: 

```
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "Root mapping definition has unsupported parameters:  [severity : {index=true, type=keyword}] [@timestamp : {type=date}] [@version : {type=keyword}] [message : {index=true, type=text}] [fields : {dynamic=true, properties={}}]"
      }
    ],
    "type": "mapper_parsing_exception",
    "reason": "Failed to parse mapping [properties]: Root mapping definition has unsupported parameters:  [severity : {index=true, type=keyword}] [@timestamp : {type=date}] [@version : {type=keyword}] [message : {index=true, type=text}] [fields : {dynamic=true, properties={}}]",
    "caused_by": {
      "type": "mapper_parsing_exception",
      "reason": "Root mapping definition has unsupported parameters:  [severity : {index=true, type=keyword}] [@timestamp : {type=date}] [@version : {type=keyword}] [message : {index=true, type=text}] [fields : {dynamic=true, properties={}}]"
    }
  },
  "status": 400
}
```