### PR TITLE
breaking change in 0.8.6

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,4 +133,4 @@ class ElasticsearchTransport extends Transport {
 
 winston.transports.Elasticsearch = ElasticsearchTransport;
 
-module.exports = {ElasticsearchTransport}
+module.exports = ElasticsearchTransport;


### PR DESCRIPTION
This pr fixes #127 

Description from issue:
0.8.6 introduced a breaking change in the way the library is exported, exporting {ElasticSearchTransport} instead of ElasticSearchTransport.

it looks like it was introduced in: https://github.com/vanthome/winston-elasticsearch/pull/126