### PR TITLE
Remove console statement on bulk write error

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -118,8 +118,6 @@ BulkWriter.prototype.write = function write(body) {
     debug('error occurred', e);
     this.stop();
     this.checkEsConnection();
-    // eslint-disable-next-line no-console
-    console.log(e);
     // Rethrow in next run loop to prevent UnhandledPromiseRejectionWarning
     process.nextTick(() => {
       thiz.transport.emit('error', e);


### PR DESCRIPTION
Hi @vanthome!

I'd like to start by saying how much I appreciate that you took the time to write this transport - I've used it often and it's wonderful.

Would you consider removing the console statement as proposed in this PR, or consider a strategy in which it can be switched off?

We have a proxy setup to elasticsearch and when we are configuring it on the fly, it can result in the client console output exploding due to expected failures `ResponseError`. There is a debug statement already that you have that I think works quite well, although for user friendliness I can see why you've opted to output it by default.

What do you think?