### PR TITLE
Implemented retries for failed documents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-elasticsearch",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes #139 

Currently the buffer fills up with failed documents. This commit adds a retry counter - after the number of retries has been exceeded then the document is discarded.