### PR TITLE
Allow process termination even if buffering is enabled

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,10 @@
   "extends": [
     "eslint-config-airbnb-base"
   ],
+  "env": {
+    "node": true,
+    "mocha": true
+  },
   "rules": {
     "arrow-body-style": 0,
     "consistent-this": ["error", "thiz"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -8,17 +8,27 @@
   },
   "rules": {
     "arrow-body-style": 0,
-    "consistent-this": ["error", "thiz"],
+    "consistent-this": [
+      "error",
+      "thiz"
+    ],
     "comma-dangle": 0,
     "global-require": 0,
-    "no-unused-vars": ["error", {
-      "vars": "all", "args": "none" }
+    "no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "none"
+      }
     ],
     "prefer-template": 0,
-    "prefer-const": [2, {
-      "destructuring": "any",
-      "ignoreReadBeforeAssign": true
-    }],
+    "prefer-const": [
+      2,
+      {
+        "destructuring": "any",
+        "ignoreReadBeforeAssign": true
+      }
+    ],
     "space-before-function-paren": 0,
     "prefer-object-spread": 0,
     "strict": 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ before_install:
 before_script:
   - sleep 100
 after_success:
-  - 'npm run coveralls'
-  - 'cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js'
+  - "npm run coveralls"
+  - "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1
   - /tmp/elasticsearch/bin/elasticsearch --daemonize -E path.data=/tmp
   - until curl --silent -XGET --fail http://localhost:9200; do printf '.'; sleep 1; done
-  - npm install
+  - npm ci
 git:
   depth: 10
 before_install:

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -70,6 +70,7 @@ BulkWriter.prototype.flush = function flush() {
   const bulk = this.bulk.concat();
   this.bulk = [];
   const body = [];
+  // eslint-disable-next-line object-curly-newline
   bulk.forEach(({ index, type, doc, attempts }) => {
     body.push(
       { index: { _index: index, _type: type, pipeline: this.pipeline }, attempts },
@@ -83,8 +84,8 @@ BulkWriter.prototype.flush = function flush() {
 BulkWriter.prototype.append = function append(index, type, doc) {
   if (this.options.buffering === true) {
     if (
-      typeof this.options.bufferLimit === 'number' &&
-      this.bulk.length >= this.options.bufferLimit
+      typeof this.options.bufferLimit === 'number'
+      && this.bulk.length >= this.options.bufferLimit
     ) {
       debug('message discarded because buffer limit exceeded');
       // @todo: i guess we can use callback to notify caller
@@ -117,7 +118,6 @@ BulkWriter.prototype.write = function write(body) {
       if (res && res.errors && res.items) {
         res.items.forEach((item) => {
           if (item.index && item.index.error) {
-            // eslint-disable-next-line no-console
             debug('elasticsearch index error', item.index);
             throw new Error('ElasticSearch index error');
           }
@@ -128,6 +128,7 @@ BulkWriter.prototype.write = function write(body) {
       // rollback this.bulk array
       const newBody = [];
       for (let i = 0; i < body.length; i += 2) {
+        // eslint-disable-next-line prefer-destructuring
         const attempts = body[i].attempts;
         if (attempts < thiz.retryLimit) {
           newBody.push({
@@ -137,7 +138,7 @@ BulkWriter.prototype.write = function write(body) {
             attempts: attempts + 1,
           });
         } else {
-          debug('retry attempts exceeded')
+          debug('retry attempts exceeded');
         }
       }
 
@@ -174,31 +175,32 @@ BulkWriter.prototype.checkEsConnection = function checkEsConnection() {
       thiz.client.cluster.health({
         timeout: '5s',
         wait_for_nodes: '1',
-        wait_for_status: 'yellow'})
+        wait_for_status: 'yellow'
+      })
         .then(
-        (res) => {
-          thiz.esConnection = true;
-          // Ensure mapping template is existing if desired
-          if (thiz.options.ensureMappingTemplate) {
-            thiz.ensureMappingTemplate(fulfill, reject);
-          } else {
-            fulfill(true);
+          (res) => {
+            thiz.esConnection = true;
+            // Ensure mapping template is existing if desired
+            if (thiz.options.ensureMappingTemplate) {
+              thiz.ensureMappingTemplate(fulfill, reject);
+            } else {
+              fulfill(true);
+            }
+            if (thiz.options.buffering === true) {
+              debug('starting bulk writer');
+              thiz.running = true;
+              thiz.tick();
+            }
+          },
+          (err) => {
+            debug('checking for connection');
+            if (operation.retry(err)) {
+              return;
+            }
+            // thiz.esConnection = false;
+            reject(new Error('Cannot connect to ES'));
           }
-          if (thiz.options.buffering === true) {
-            debug('starting bulk writer');
-            thiz.running = true;
-            thiz.tick();
-          }
-        },
-        (err) => {
-          debug('checking for connection');
-          if (operation.retry(err)) {
-            return;
-          }
-          // thiz.esConnection = false;
-          reject(new Error('Cannot connect to ES'));
-        }
-      );
+        );
     });
   });
 };
@@ -209,10 +211,9 @@ BulkWriter.prototype.ensureMappingTemplate = function ensureMappingTemplate(
 ) {
   const thiz = this;
 
-  const indexPrefix =
-    typeof thiz.options.indexPrefix === 'function'
-      ? thiz.options.indexPrefix()
-      : thiz.options.indexPrefix;
+  const indexPrefix = typeof thiz.options.indexPrefix === 'function'
+    ? thiz.options.indexPrefix()
+    : thiz.options.indexPrefix;
   // eslint-disable-next-line prefer-destructuring
   let mappingTemplate = thiz.options.mappingTemplate;
   if (mappingTemplate === null || typeof mappingTemplate === 'undefined') {

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -64,6 +64,9 @@ BulkWriter.prototype.flush = function flush() {
   if (this.bulk.length === 0) {
     debug('nothing to flush');
     return new Promise((resolve) => {
+      // pause the buffering process when there's no more bulk to flush
+      // thus allowing the process to be terminated
+      this.running = false;
       return resolve();
     });
   }
@@ -97,6 +100,11 @@ BulkWriter.prototype.append = function append(index, type, doc) {
       doc,
       attempts: 0
     });
+    // resume the buffering process
+    if (!this.running) {
+      this.running = true;
+      this.tick();
+    }
   } else {
     this.write([
       { index: { _index: index, _type: type, pipeline: this.pipeline } },

--- a/index-template-mapping.json
+++ b/index-template-mapping.json
@@ -1,5 +1,7 @@
 {
-  "index_patterns": ["logs-*"],
+  "index_patterns": [
+    "logs-*"
+  ],
   "settings": {
     "number_of_shards": 1,
     "number_of_replicas": 0,
@@ -8,15 +10,27 @@
     }
   },
   "mappings": {
-    "_source": { "enabled": true },
+    "_source": {
+      "enabled": true
+    },
     "properties": {
-      "@timestamp": { "type": "date" },
-      "@version": { "type": "keyword" },
-      "message": { "type": "text", "index": true },
-      "severity": { "type": "keyword", "index": true },
+      "@timestamp": {
+        "type": "date"
+      },
+      "@version": {
+        "type": "keyword"
+      },
+      "message": {
+        "type": "text",
+        "index": true
+      },
+      "severity": {
+        "type": "keyword",
+        "index": true
+      },
       "fields": {
         "dynamic": true,
-        "properties": { }
+        "properties": {}
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ class ElasticsearchTransport extends Transport {
     this.on('finish', (info) => {
       this.bulkWriter.schedule = () => {};
     });
-    this.on('error', (err) => {})
+    this.on('error', (err) => {});
     this.opts = opts || {};
 
     // Set defaults
@@ -109,12 +109,9 @@ class ElasticsearchTransport extends Transport {
 
     if (this.opts.apm) {
       const apm = this.opts.apm.currentTraceIds;
-      if (apm['transaction.id'])
-        entry.transaction = { id: apm['transaction.id'], ...entry.transaction };
-      if (apm['trace.id'])
-        entry.trace = { id: apm['trace.id'], ...entry.transaction };
-      if (apm['span.id'])
-        entry.span = { id: apm['span.id'], ...entry.transaction };
+      if (apm['transaction.id']) entry.transaction = { id: apm['transaction.id'], ...entry.transaction };
+      if (apm['trace.id']) entry.trace = { id: apm['trace.id'], ...entry.transaction };
+      if (apm['span.id']) entry.span = { id: apm['span.id'], ...entry.transaction };
     }
 
     this.bulkWriter.append(index, this.opts.messageType, entry);
@@ -134,11 +131,10 @@ class ElasticsearchTransport extends Transport {
       }
       const now = dayjs();
       const dateString = now.format(opts.indexSuffixPattern);
-      indexName =
-        indexPrefix +
-        (indexInterfix !== undefined ? '-' + indexInterfix : '') +
-        '-' +
-        dateString;
+      indexName = indexPrefix
+        + (indexInterfix !== undefined ? '-' + indexInterfix : '')
+        + '-'
+        + dateString;
     }
     return indexName;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -54,13 +54,11 @@ describe('the default transformer', () => {
   });
 });
 
-let logger = null;
-
 describe('a buffering logger', () => {
   it('can be instantiated', function (done) {
     this.timeout(8000);
     try {
-      logger = createLogger(true);
+      const logger = createLogger(true);
       logger.end();
     } catch (err) {
       should.not.exist(err);
@@ -74,7 +72,7 @@ describe('a buffering logger', () => {
 
   it('should log simple message to Elasticsearch', function (done) {
     this.timeout(8000);
-    logger = createLogger(true);
+    const logger = createLogger(true);
 
     logger.log(logMessage.level, `${logMessage.message}1`);
     logger.on('finish', () => {
@@ -88,7 +86,7 @@ describe('a buffering logger', () => {
 
   it('should log with or without metadata', function (done) {
     this.timeout(8000);
-    logger = createLogger(true);
+    const logger = createLogger(true);
 
     logger.info('test test');
     logger.info('test test', 'hello world');
@@ -105,7 +103,7 @@ describe('a buffering logger', () => {
 
   it('should update buffer properly in case of an error from elasticsearch.', function (done) {
     this.timeout(8000);
-    logger = createLogger(true);
+    const logger = createLogger(true);
     const transport = logger.transports[0];
     transport.bulkWriter.bulk.should.have.lengthOf(0);
 
@@ -153,7 +151,7 @@ describe('a non buffering logger', () => {
   it('can be instantiated', function (done) {
     this.timeout(8000);
     try {
-      logger = createLogger(false);
+      const logger = createLogger(false);
       logger.end();
       done();
     } catch (err) {
@@ -163,7 +161,7 @@ describe('a non buffering logger', () => {
 
   it('should log simple message to Elasticsearch', function (done) {
     this.timeout(8000);
-    logger = createLogger(false);
+    const logger = createLogger(false);
 
     logger.log(logMessage.level, `${logMessage.message}1`);
     logger.on('finish', () => {
@@ -213,6 +211,7 @@ describe('ES Re-Connection Test', () => {
     setInterval(() => {
       // eslint-disable-next-line no-console
       console.log('LOGGING...');
+      const logger = createLogger(false);
       logger.log(logMessage.level, logMessage.message, logMessage.meta,
         (err) => {
           should.not.exist(err);

--- a/test/test.js
+++ b/test/test.js
@@ -70,6 +70,11 @@ describe('a buffering logger', () => {
     }, 4000);
   });
 
+  it('can end logging without calling `logger.end`', function () {
+    this.timeout(8000);
+    createLogger(true);
+  });
+
   it('should log simple message to Elasticsearch', function (done) {
     this.timeout(8000);
     const logger = createLogger(true);


### PR DESCRIPTION
This (winston) transport is currently holding Timers (i.e. `setTimeout`) in place when `buffering === true` through calls between [`BulkWriter.prototype.tick`](https://github.com/vanthome/winston-elasticsearch/blob/03414b2c1bd62a2294cb7d61e4d4c0347ee3fff6/bulk_writer.js#L58) and [`BulkWriter.prototype.schedule`](https://github.com/vanthome/winston-elasticsearch/blob/03414b2c1bd62a2294cb7d61e4d4c0347ee3fff6/bulk_writer.js#L41) causing the Node.js runtime to stay alive even though there's nothing more to process.

This PR allows the transport schedule to be paused when no more bulk need to be inserted into ES thus allowing the runtime to be properly stopped.