### PR TITLE
fix for broken template mapping json

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ If multiple objects are provided as arguments, the contents are stringified.
 - `messageType` [`_doc`] the type (path segment after the index path) under which the messages are stored under the index.
 - `transformer` [see below] a transformer function to transform logged data into a different message structure.
 - `ensureMappingTemplate` [`true`] If set to `true`, the given `mappingTemplate` is checked/ uploaded to ES when the module is sending the fist log message to make sure the log messages are mapped in a sensible manner.
-- `mappingTemplate` [see file `index-template-mapping.json` file] the mapping template to be ensured as parsed JSON.
+- `mappingTemplate` [see file `index-template-mapping-es-gte-7.json` or `index-template-mapping-es-lte-6.json`] the mapping template to be ensured as parsed JSON.
+- `elasticsearchVersion` [`7`] Elasticsearch version you are using. This helps decide the default mapping template that will be used when `ensureMappingTemplate` is `true` and `mappingTemplate` is `undefined`
 - `flushInterval` [`2000`] distance between bulk writes in ms.
 - `client` An [elasticsearch client](https://www.npmjs.com/package/@elastic/elasticsearch) instance. If given, all following options are ignored.
 - `clientOpts` An object hash passed to the ES client. See [its docs](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/client-configuration.html) for supported options.

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -187,36 +187,36 @@ BulkWriter.prototype.checkEsConnection = function checkEsConnection() {
         wait_for_status: 'yellow'
       })
         .then(
-        (res) => {
-          thiz.esConnection = true;
-          const start = () => {
-            if (thiz.options.buffering === true) {
-              debug('starting bulk writer');
-              thiz.running = true;
-              thiz.tick();
-            }
-          };
-          // Ensure mapping template is existing if desired
-          if (thiz.options.ensureMappingTemplate) {
-            thiz.ensureMappingTemplate((res1) => {
-              fulfill(res1);
+          (res) => {
+            thiz.esConnection = true;
+            const start = () => {
+              if (thiz.options.buffering === true) {
+                debug('starting bulk writer');
+                thiz.running = true;
+                thiz.tick();
+              }
+            };
+            // Ensure mapping template is existing if desired
+            if (thiz.options.ensureMappingTemplate) {
+              thiz.ensureMappingTemplate((res1) => {
+                fulfill(res1);
+                start();
+              }, reject);
+            } else {
+              fulfill(true);
               start();
-            }, reject);
-          } else {
-            fulfill(true);
-            start();
+            }
+          },
+          (err) => {
+            debug('re-checking for connection to ES');
+            if (operation.retry(err)) {
+              return;
+            }
+            thiz.esConnection = false;
+            debug('cannot connect to ES');
+            reject(new Error('Cannot connect to ES'));
           }
-        },
-        (err) => {
-          debug('re-checking for connection to ES');
-          if (operation.retry(err)) {
-            return;
-          }
-          thiz.esConnection = false;
-          debug('cannot connect to ES');
-          reject(new Error('Cannot connect to ES'));
-        }
-      );
+        );
     });
   });
 };

--- a/index-template-mapping-es-gte-7.json
+++ b/index-template-mapping-es-gte-7.json
@@ -1,0 +1,22 @@
+{
+  "index_patterns": ["logs-*"],
+  "settings": {
+    "number_of_shards": 1,
+    "number_of_replicas": 0,
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "properties": {
+      "@timestamp": { "type": "date" },
+      "@version": { "type": "keyword" },
+      "message": { "type": "text" },
+      "severity": { "type": "keyword" },
+      "fields": {
+        "dynamic": true,
+        "properties": { }
+      }
+    }
+  }
+}

--- a/index-template-mapping-es-lte-6.json
+++ b/index-template-mapping-es-lte-6.json
@@ -10,7 +10,7 @@
     }
   },
   "mappings": {
-    "winston-elasticsearch-test-log-type": {
+    "_doc": {
       "properties": {
         "@timestamp": {
           "type": "date"

--- a/index-template-mapping.json
+++ b/index-template-mapping.json
@@ -10,27 +10,26 @@
     }
   },
   "mappings": {
-    "_source": {
-      "enabled": true
-    },
-    "properties": {
-      "@timestamp": {
-        "type": "date"
-      },
-      "@version": {
-        "type": "keyword"
-      },
-      "message": {
-        "type": "text",
-        "index": true
-      },
-      "severity": {
-        "type": "keyword",
-        "index": true
-      },
-      "fields": {
-        "dynamic": true,
-        "properties": {}
+    "winston-elasticsearch-test-log-type": {
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "@version": {
+          "type": "keyword"
+        },
+        "message": {
+          "type": "text",
+          "index": true
+        },
+        "severity": {
+          "type": "keyword",
+          "index": true
+        },
+        "fields": {
+          "dynamic": true,
+          "properties": {}
+        }
       }
     }
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ export interface ElasticsearchTransportOptions extends TransportStream.Transport
   transformer?: Transformer;
   mappingTemplate?: { [key: string]: any };
   ensureMappingTemplate?: boolean;
+  elasticsearchVersion?: number;
   flushInterval?: number;
   waitForActiveShards?: number | 'all';
   handleExceptions?: boolean;

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ class ElasticsearchTransport extends Transport {
       messageType: '_doc',
       transformer: defaultTransformer,
       ensureMappingTemplate: true,
+      elasticsearchVersion: 7,
       flushInterval: 2000,
       waitForActiveShards: 1,
       handleExceptions: false,
@@ -79,6 +80,7 @@ class ElasticsearchTransport extends Transport {
       indexPrefix: opts.indexPrefix,
       buffering: opts.buffering,
       bufferLimit: opts.buffering ? opts.bufferLimit : 0,
+      elasticsearchVersion: opts.elasticsearchVersion,
     };
 
     this.bulkWriter = new BulkWriter(this, this.client, bulkWriteropts);

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,15 @@ function NullLogger(config) {
   this.close = (msg) => {};
 }
 
+process.on('unhandledRejection', (error) => {
+  console.error(error);
+  process.exit(1);
+});
+process.on('uncaughtException', (error) => {
+  console.error(error);
+  process.exit(1);
+});
+
 function createLogger(buffering) {
   return winston.createLogger({
     transports: [


### PR DESCRIPTION
Seems like the mapping part of json file needs to be wrapped into a "type" (which can be any name). This is on elasticsearch 6. I am not sure if older elastic used to accept without it.

e.g.
```
"mapping": {
  "asdasd": {
     "properties": { .... }
  }
}
```