### PR TITLE
Handle invalid Transport and fix problem on async loop during error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import Agent from 'elastic-apm-node';
+import * as Agent from 'elastic-apm-node';
 import { Client, ClientOptions, ApiResponse } from '@elastic/elasticsearch';
 import TransportStream = require('winston-transport');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "winston-elasticsearch",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -139,12 +139,6 @@ describe('a buffering logger', () => {
     const transport = logger.transports[0];
     transport.bulkWriter.bulk.should.have.lengthOf(0);
 
-    // mock client.bulk to throw an error
-    transport.client.bulk = () => {
-      return Promise.reject(new Error('Test Error'));
-    };
-    logger.info('test');
-
     logger.on('error', (err) => {
       should.exist(err);
       transport.bulkWriter.bulk.should.have.lengthOf(1);
@@ -152,6 +146,12 @@ describe('a buffering logger', () => {
       transport.bulkWriter.bulk = [];
       done();
     });
+    // mock client.bulk to throw an error
+    logger.info('test');
+    transport.client.bulk = () => {
+      return Promise.reject(new Error('Test Error'));
+    };
+    logger.info('test');
     logger.end();
   });
 
@@ -209,13 +209,12 @@ describe('a non buffering logger', () => {
   });
 });
 
-/*
 describe('a defective log transport', () => {
   it('emits an error', function (done) {
     this.timeout(40000);
     const transport = new (winston.transports.Elasticsearch)({
       clientOpts: {
-        host: 'http://does-not-exist.test:9200',
+        node: 'http://does-not-exist.test:9200',
         log: NullLogger
       }
     });
@@ -225,15 +224,15 @@ describe('a defective log transport', () => {
       done();
     });
 
-    // eslint-disable-next-line no-unused-vars
     const defectiveLogger = winston.createLogger({
       transports: [
         transport
       ]
     });
+
+    defectiveLogger.info('test');
   });
 });
-*/
 
 // Manual test which allows to test re-connection of the ES client for unavailable ES instance.
 // Must be combined with --no-timeouts option for mocha


### PR DESCRIPTION
I used winston-elasticseach to send logs on my ELK. I had some problems with auth on ElasticSearch and that made my server run really slowly because winston couldn't send logs....
I made this pull request to fix those 2 problems:
 - Handle invalid transport: It will not emit an error event then, you can handle it as you want in your codebase.
 - Handle error on failed report: It will emit an error if one of the bulk reach the max attempt. I think there is an other way to handle that but I give you a begin of idea.