### PR TITLE
support Elasticsearch datastreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Will produce:
 ### Datastreams
 
 Elasticsearch 7.9 and higher supports [Datstreams](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html).  
+
 When `dataStream: true` is set, bulk indexing happens with `create` instead of `index`, and also the default naming convention is 
 `logs-*-*`, which will match the built-in [Index template](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html) and [ILM](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html) policy,
 automatically creating a datastream.   

--- a/README.md
+++ b/README.md
@@ -268,8 +268,7 @@ Will produce:
 
 Elasticsearch 7.9 and higher supports [Datstreams](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html).  
 
-When `dataStream: true` is set, bulk indexing happens with `create` instead of `index`, and also the default naming convention is 
-`logs-*-*`, which will match the built-in [Index template](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html) and [ILM](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html) policy,
+When `dataStream: true` is set, bulk indexing happens with `create` instead of `index`, and also the default naming convention is `logs-*-*`, which will match the built-in [Index template](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html) and [ILM](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html) policy,
 automatically creating a datastream.   
 
 By default, the datastream will be named `logs-app-default`, but you can modify that by setting `indexPrefix` in options, and `indexInterfix` in a transformer, resulting in `logs-<indexPrefix>-<indexInterfix>`.  

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If multiple objects are provided as arguments, the contents are stringified.
 
 - `level` [`info`] Messages logged with a severity greater or equal to the given one are logged to ES; others are discarded.
 - `index` [none] The index to be used. This option is mutually exclusive with `indexPrefix`.
-- `indexPrefix` [`logs`] The prefix to use to generate the index name according to the pattern `<indexPrefix>-<indexInterfix>-<indexSuffixPattern>`. Can be string or function, returning the string to use.
+- `indexPrefix` [`logs` | when dataStream:true, `app`] The prefix to use to generate the index name according to the pattern `<indexPrefix>-<indexInterfix>-<indexSuffixPattern>`. Can be string or function, returning the string to use.
 - `indexSuffixPattern` [`YYYY.MM.DD`] a [Moment.js](http://momentjs.com/) compatible date/ time pattern.
 - `messageType` [`_doc`] The type (path segment after the index path) under which the messages are stored under the index.
 - `transformer` [see below] A transformer function to transform logged data into a different message structure.
@@ -86,6 +86,7 @@ If multiple objects are provided as arguments, the contents are stringified.
 - `buffering` [true] Boolean flag to enable or disable messages buffering. The `bufferLimit` option is ignored if set to `false`.
 - `bufferLimit` [null] Limit for the number of log messages in the buffer.
 - `apm` [null] Inject [apm client](https://www.npmjs.com/package/elastic-apm-node) to link elastic logs with elastic apm traces.
+- `dataStream` [false] Use Elasticsearch [datastreams](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html).
 
 ### Logging of ES Client
 
@@ -262,6 +263,19 @@ Will produce:
   }
 }
 ```
+
+### Datastreams
+
+Elasticsearch 7.9 and higher supports [Datstreams](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html).  
+When `dataStream: true` is set, bulk indexing happens with `create` instead of `index`, and also the default naming convention is 
+`logs-*-*`, which will match the built-in [Index template](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html) and [ILM](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html) policy,
+automatically creating a datastream.   
+
+By default, the datastream will be named `logs-app-default`, but you can modify that by setting `indexPrefix` in options, and `indexInterfix` in a transformer, resulting in `logs-<indexPrefix>-<indexInterfix>`.  
+
+Alternatively, you can simply set the `index` option to anything that matches `logs-*-*` to make use of the built-in template and ILM policy. 
+
+If `dataStream: true` is enabled, AND ( you are using Elasticsearch < 7.9 OR ( you have set a custom `index` that does not match `logs-*-*`  AND you have not created a custom matching template in Elasticsearch)), a normal index will be created.
 
 ### Notice
 

--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -79,7 +79,11 @@ BulkWriter.prototype.flush = function flush() {
   // eslint-disable-next-line object-curly-newline
   bulk.forEach(({ index, type, doc, attempts }) => {
     body.push(
-      { index: { _index: index, _type: type, pipeline: this.pipeline }, attempts },
+      { [this.options.dataStream ? 'create' : 'index']: { 
+        _index: index,
+         _type: type, 
+         pipeline: this.pipeline 
+        }, attempts },
       doc
     );
   });

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ export interface Transformer {
 }
 
 export interface ElasticsearchTransportOptions extends TransportStream.TransportStreamOptions {
+  dataStream?: boolean;
   apm?: typeof Agent;
   timestamp?: () => string;
   level?: string;


### PR DESCRIPTION
In the most minimal sense, the only thing required to make a datastream work is to change `index` to `create` in the bulk action, and then for either `index` to match `logs-*.*` or to match a the user's custom template pattern.

However by explicitly enabling it, we can manage the experience by conforming to the above while still allowing use of `indexPrefix` and `indexInterfix`.  

Here's some of the `README.md` update:

### Datastreams

Elasticsearch 7.9 and higher supports [Datstreams](https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html).  

When `dataStream: true` is set, bulk indexing happens with `create` instead of `index`, and also the default naming convention is `logs-*-*`, which will match the built-in [Index template](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-templates.html) and [ILM](https://www.elastic.co/guide/en/elasticsearch/reference/master/index-lifecycle-management.html) policy,
automatically creating a datastream.   

By default, the datastream will be named `logs-app-default`, but you can modify that by setting `indexPrefix` in options, and `indexInterfix` in a transformer, resulting in `logs-<indexPrefix>-<indexInterfix>`.  

Alternatively, you can simply set the `index` option to anything that matches `logs-*-*` to make use of the built-in template and ILM policy. 

If `dataStream: true` is enabled, AND ( you are using Elasticsearch < 7.9 OR ( you have set a custom `index` that does not match `logs-*-*`  AND you have not created a custom matching template in Elasticsearch)), a normal index will be created.
