### PR TITLE
Optional elastic-apm-node package

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,3 @@
-import * as Agent from 'elastic-apm-node';
 import { Client, ClientOptions, ApiResponse } from '@elastic/elasticsearch';
 import TransportStream = require('winston-transport');
 
@@ -15,7 +14,7 @@ export interface Transformer {
 
 export interface ElasticsearchTransportOptions extends TransportStream.TransportStreamOptions {
   dataStream?: boolean;
-  apm?: typeof Agent;
+  apm?: any; // typeof Agent;
   timestamp?: () => string;
   level?: string;
   index?: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -795,9 +795,9 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
-      "integrity": "sha512-EfB5OHNYp1F4px/LI/FEnGylop7nOqkQ1LRzCM0KccA2U8tvV8w01KBv37LbO7nW4H+YhKyo2LcJhRwjjV17QQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
+      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -807,7 +807,7 @@
         "ignore": "^4.0.6",
         "import-fresh": "^3.2.1",
         "js-yaml": "^3.13.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "strip-json-comments": "^3.1.1"
       },
@@ -926,7 +926,8 @@
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "optional": true
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -949,7 +950,8 @@
     "after-all-results": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/after-all-results/-/after-all-results-2.0.0.tgz",
-      "integrity": "sha1-asL8ICtQD4jaj09VMM+hAPTGotA="
+      "integrity": "sha1-asL8ICtQD4jaj09VMM+hAPTGotA=",
+      "optional": true
     },
     "aggregate-error": {
       "version": "3.0.1",
@@ -1070,9 +1072,9 @@
       "dev": true
     },
     "astral-regex": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
     },
     "async": {
@@ -1084,6 +1086,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
       "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
+      "optional": true,
       "requires": {
         "lru-cache": "^4.0.0"
       }
@@ -1091,12 +1094,14 @@
     "async-value": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/async-value/-/async-value-1.2.2.tgz",
-      "integrity": "sha1-hFF6Hny2saW14YH6Mb4QQ3t/sSU="
+      "integrity": "sha1-hFF6Hny2saW14YH6Mb4QQ3t/sSU=",
+      "optional": true
     },
     "async-value-promise": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/async-value-promise/-/async-value-promise-1.1.1.tgz",
       "integrity": "sha512-c2RFDKjJle1rHa0YxN9Ysu97/QBu3Wa+NOejJxsX+1qVDJrkD3JL/GN1B3gaILAEXJXbu/4Z1lcoCHFESe/APA==",
+      "optional": true,
       "requires": {
         "async-value": "^1.2.2"
       }
@@ -1110,7 +1115,8 @@
     "await-event": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/await-event/-/await-event-2.1.0.tgz",
-      "integrity": "sha1-eOn5JoS65AIvn6C18xShFVD5qnY="
+      "integrity": "sha1-eOn5JoS65AIvn6C18xShFVD5qnY=",
+      "optional": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -1148,6 +1154,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "optional": true,
       "requires": {
         "safe-buffer": "5.1.2"
       },
@@ -1155,7 +1162,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         }
       }
     },
@@ -1177,7 +1185,8 @@
     "binary-search": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/binary-search/-/binary-search-1.3.6.tgz",
-      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA=="
+      "integrity": "sha512-nbE1WxOTTrUWIfsfZ4aHGYu5DOuNkbxGokjV6Z2kxfJK3uaAb8zNK1muzOeipoLHZjInT4Br88BHpzevc681xA==",
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1202,6 +1211,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/breadth-filter/-/breadth-filter-2.0.0.tgz",
       "integrity": "sha512-thQShDXnFWSk2oVBixRCyrWsFoV5tfOpWKHmxwafHQDNxCfDBk539utpvytNjmlFrTMqz41poLwJvA1MW3z0MQ==",
+      "optional": true,
       "requires": {
         "object.entries": "^1.0.4"
       }
@@ -1411,12 +1421,14 @@
     "console-log-level": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/console-log-level/-/console-log-level-1.4.1.tgz",
-      "integrity": "sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ=="
+      "integrity": "sha512-VZzbIORbP+PPcN/gg3DXClTLPLg5Slwd5fL2MIc+o1qZ4BXBvWyc6QxPk6T/Mkr6IVjRpoAGf32XxP3ZWMVRcQ==",
+      "optional": true
     },
     "container-info": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/container-info/-/container-info-1.0.1.tgz",
-      "integrity": "sha512-wk/+uJvPHOFG+JSwQS+fw6H6yw3Oyc8Kw9L4O2MN817uA90OqJ59nlZbbLPqDudsjJ7Tetee3pwExdKpd2ahjQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/container-info/-/container-info-1.1.0.tgz",
+      "integrity": "sha512-eD2zLAmxGS2kmL4f1jY8BdOqnmpL6X70kvzTBW/9FIQnxoxiBJ4htMsTmtPLPWRs7NHYFvqKQ1VtppV08mdsQA==",
+      "optional": true
     },
     "contains-path": {
       "version": "0.1.0",
@@ -1444,7 +1456,8 @@
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "optional": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1485,9 +1498,9 @@
       }
     },
     "dayjs": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.9.6.tgz",
-      "integrity": "sha512-HngNLtPEBWRo8EFVmHFmSXAjtCX8rGNqeXQI0Gh7wCTSqwaKgPIDqu9m07wABVopNwzvOeCb+2711vQhDlcIXw=="
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
     },
     "debug": {
       "version": "4.3.1",
@@ -1566,9 +1579,10 @@
       }
     },
     "elastic-apm-http-client": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-9.4.2.tgz",
-      "integrity": "sha512-zhOf0+cIO45tJgvQw3fWjXRWqO2MizCC9cvnQpMH2NNsQItXnZfJilhmiYJr8XYi50FxnlOvaav8koZ6tcObmw==",
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-9.4.3.tgz",
+      "integrity": "sha512-TtcuuIOFmDOTmMupPJNsovO2Hj9eOH99UDs3UzoR5C4Xybhj76E6Dld6FYrrE1XnYBt0UPAKq8L9F0U+uFidrg==",
+      "optional": true,
       "requires": {
         "breadth-filter": "^2.0.0",
         "container-info": "^1.0.1",
@@ -1582,9 +1596,10 @@
       }
     },
     "elastic-apm-node": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.9.0.tgz",
-      "integrity": "sha512-J47rPyZxHZ/EMVW33e2MEI3sStkO0Ro+WfDgZtMApGDytTgGNF9XQ07SJSQGcQLxKR/YgSNoXdI8eBIgViTRWQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.10.0.tgz",
+      "integrity": "sha512-H1DOrpr0CwX88awQqSM4UbHGdfsk7xJ4GM6R1uYuFk1zILX/eozylcm6dYSKirpXwwMLxGSRFTOCaMa8fqiLjQ==",
+      "optional": true,
       "requires": {
         "after-all-results": "^2.0.0",
         "async-value-promise": "^1.1.1",
@@ -1592,7 +1607,7 @@
         "console-log-level": "^1.4.1",
         "cookie": "^0.4.0",
         "core-util-is": "^1.0.2",
-        "elastic-apm-http-client": "^9.4.1",
+        "elastic-apm-http-client": "^9.4.2",
         "end-of-stream": "^1.4.4",
         "error-stack-parser": "^2.0.6",
         "escape-string-regexp": "^4.0.0",
@@ -1606,7 +1621,6 @@
         "object-identity-map": "^1.0.2",
         "original-url": "^1.2.3",
         "read-pkg-up": "^7.0.1",
-        "redact-secrets": "^1.0.0",
         "relative-microtime": "^2.0.0",
         "require-ancestors": "^1.0.0",
         "require-in-the-middle": "^5.0.3",
@@ -1616,18 +1630,21 @@
         "sql-summary": "^1.0.1",
         "stackman": "^4.0.1",
         "traceparent": "^1.0.0",
+        "traverse": "^0.6.6",
         "unicode-byte-truncate": "^1.0.0"
       },
       "dependencies": {
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "optional": true
         },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
           "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "optional": true,
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
@@ -1637,6 +1654,7 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
           "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "optional": true,
           "requires": {
             "p-locate": "^4.1.0"
           }
@@ -1645,6 +1663,7 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "optional": true,
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -1653,6 +1672,7 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
           "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "optional": true,
           "requires": {
             "p-limit": "^2.2.0"
           }
@@ -1660,12 +1680,14 @@
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "optional": true
         },
         "parse-json": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
-          "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "optional": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "error-ex": "^1.3.1",
@@ -1676,12 +1698,14 @@
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "optional": true
         },
         "read-pkg": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
           "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "optional": true,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
             "normalize-package-data": "^2.5.0",
@@ -1692,7 +1716,8 @@
             "type-fest": {
               "version": "0.6.0",
               "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "optional": true
             }
           }
         },
@@ -1700,6 +1725,7 @@
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
           "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "optional": true,
           "requires": {
             "find-up": "^4.1.0",
             "read-pkg": "^5.2.0",
@@ -1709,7 +1735,8 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "optional": true
         }
       }
     },
@@ -1744,7 +1771,8 @@
     "error-callsites": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/error-callsites/-/error-callsites-2.0.3.tgz",
-      "integrity": "sha512-v036z4IEffZFE5kBkV5/F2MzhLnG0vuDyN+VXpzCf4yWXvX/1WJCI0A+TGTr8HWzBfCw5k8gr9rwAo09V+obTA=="
+      "integrity": "sha512-v036z4IEffZFE5kBkV5/F2MzhLnG0vuDyN+VXpzCf4yWXvX/1WJCI0A+TGTr8HWzBfCw5k8gr9rwAo09V+obTA==",
+      "optional": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1765,6 +1793,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
       "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "optional": true,
       "requires": {
         "stackframe": "^1.1.1"
       }
@@ -1809,13 +1838,13 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.15.0.tgz",
-      "integrity": "sha512-Vr64xFDT8w30wFll643e7cGrIkPEU50yIiI36OdSIDoSGguIeaLzBo0vpGvzo9RECUqq7htURfwEtKqwytkqzA==",
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.18.0.tgz",
+      "integrity": "sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@eslint/eslintrc": "^0.2.2",
+        "@eslint/eslintrc": "^0.3.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -1839,7 +1868,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash": "^4.17.19",
+        "lodash": "^4.17.20",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -1848,7 +1877,7 @@
         "semver": "^7.2.1",
         "strip-ansi": "^6.0.0",
         "strip-json-comments": "^3.1.0",
-        "table": "^5.2.3",
+        "table": "^6.0.4",
         "text-table": "^0.2.0",
         "v8-compile-cache": "^2.0.3"
       },
@@ -2208,6 +2237,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-stream-to-buffer/-/fast-stream-to-buffer-1.0.0.tgz",
       "integrity": "sha512-bI/544WUQlD2iXBibQbOMSmG07Hay7YrpXlKaeGTPT7H7pC0eitt3usak5vUwEvCGK/O7rUAM3iyQValGU22TQ==",
+      "optional": true,
       "requires": {
         "end-of-stream": "^1.4.1"
       }
@@ -2332,9 +2362,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.0.tgz",
-      "integrity": "sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
       "dev": true
     },
     "fn.name": {
@@ -2372,7 +2402,8 @@
     "forwarded-parse": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.1.tgz",
-      "integrity": "sha512-8Jh3uv3iaaTTvH3vM4qyRjKfe5dvR/THhiPY5zhsfFa/UviqnEd3hqNyxEtRCwL3+L2vv8JsanGZ5XHQcncyUA=="
+      "integrity": "sha512-8Jh3uv3iaaTTvH3vM4qyRjKfe5dvR/THhiPY5zhsfFa/UviqnEd3hqNyxEtRCwL3+L2vv8JsanGZ5XHQcncyUA==",
+      "optional": true
     },
     "fromentries": {
       "version": "1.2.0",
@@ -2561,6 +2592,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/http-headers/-/http-headers-3.0.2.tgz",
       "integrity": "sha512-87E1I+2Wg4dxxz4rcxElo3dxO/w1ZtgL1yA0Sb6vH3qU16vRKq1NjWQv9SCY3ly2OQROcoxHZOUpmelS+k6wOw==",
+      "optional": true,
       "requires": {
         "next-line": "^1.1.0"
       }
@@ -2569,6 +2601,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/http-request-to-url/-/http-request-to-url-1.0.0.tgz",
       "integrity": "sha512-YYx0lKXG9+T1fT2q3ZgXLczMI3jW09g9BvIA6L3BG0tFqGm83Ka/+RUZGANRG7Ut/yueD7LPcZQ/+pA5ndNajw==",
+      "optional": true,
       "requires": {
         "await-event": "^2.1.0",
         "socket-location": "^1.0.0"
@@ -2592,9 +2625,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.2.tgz",
-      "integrity": "sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -2610,7 +2643,8 @@
     "in-publish": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
-      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
+      "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ==",
+      "optional": true
     },
     "indent-string": {
       "version": "4.0.0",
@@ -2666,7 +2700,8 @@
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -2687,6 +2722,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
       "integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
+      "optional": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -2695,6 +2731,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-native/-/is-native-1.0.1.tgz",
       "integrity": "sha1-zRjMFi6EUNaDtbq+eayZwUVElnU=",
+      "optional": true,
       "requires": {
         "is-nil": "^1.0.0",
         "to-source-code": "^1.0.0"
@@ -2703,7 +2740,8 @@
     "is-nil": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-nil/-/is-nil-1.0.1.tgz",
-      "integrity": "sha1-LauingtYUGOHXntTnQcfWxWTeWk="
+      "integrity": "sha1-LauingtYUGOHXntTnQcfWxWTeWk=",
+      "optional": true
     },
     "is-number": {
       "version": "7.0.0",
@@ -2724,11 +2762,6 @@
       "requires": {
         "has-symbols": "^1.0.1"
       }
-    },
-    "is-secret": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-secret/-/is-secret-1.2.1.tgz",
-      "integrity": "sha512-VtBantcgKL2a64fDeCmD1JlkHToh3v0bVOhyJZ5aGTjxtCgrdNcjaC9GaaRFXi19gA4/pYFpnuyoscIgQCFSMQ=="
     },
     "is-stream": {
       "version": "2.0.0",
@@ -2926,7 +2959,8 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -3003,7 +3037,8 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "optional": true
     },
     "load-json-file": {
       "version": "2.0.0",
@@ -3021,6 +3056,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/load-source-map/-/load-source-map-1.0.0.tgz",
       "integrity": "sha1-MY9JkFzopwnft8w/FvPv47zx3QU=",
+      "optional": true,
       "requires": {
         "in-publish": "^2.0.0",
         "semver": "^5.3.0",
@@ -3030,7 +3066,8 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "optional": true
         }
       }
     },
@@ -3148,6 +3185,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "optional": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -3173,12 +3211,14 @@
     "mapcap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mapcap/-/mapcap-1.0.0.tgz",
-      "integrity": "sha512-KcNlZSlFPx+r1jYZmxEbTVymG+dIctf10WmWkuhrhrblM+KMoF77HelwihL5cxYlORye79KoR4IlOOk99lUJ0g=="
+      "integrity": "sha512-KcNlZSlFPx+r1jYZmxEbTVymG+dIctf10WmWkuhrhrblM+KMoF77HelwihL5cxYlORye79KoR4IlOOk99lUJ0g==",
+      "optional": true
     },
     "measured-core": {
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/measured-core/-/measured-core-1.51.1.tgz",
       "integrity": "sha512-DZQP9SEwdqqYRvT2slMK81D/7xwdxXosZZBtLVfPSo6y5P672FBTbzHVdN4IQyUkUpcVOR9pIvtUy5Ryl7NKyg==",
+      "optional": true,
       "requires": {
         "binary-search": "^1.3.3",
         "optional-js": "^2.0.0"
@@ -3188,6 +3228,7 @@
       "version": "1.51.1",
       "resolved": "https://registry.npmjs.org/measured-reporting/-/measured-reporting-1.51.1.tgz",
       "integrity": "sha512-JCt+2u6XT1I5lG3SuYqywE0e62DJuAzBcfMzWGUhIYtPQV2Vm4HiYt/durqmzsAbZV181CEs+o/jMKWJKkYIWw==",
+      "optional": true,
       "requires": {
         "console-log-level": "^1.4.1",
         "mapcap": "^1.0.0",
@@ -3352,12 +3393,14 @@
     "module-details-from-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is="
+      "integrity": "sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=",
+      "optional": true
     },
     "monitor-event-loop-delay": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/monitor-event-loop-delay/-/monitor-event-loop-delay-1.0.0.tgz",
-      "integrity": "sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q=="
+      "integrity": "sha512-YRIr1exCIfBDLZle8WHOfSo7Xg3M+phcZfq9Fx1L6Abo+atGp7cge5pM7PjyBn4s1oZI/BRD4EMrzQBbPpVb5Q==",
+      "optional": true
     },
     "ms": {
       "version": "2.1.2",
@@ -3379,7 +3422,8 @@
     "next-line": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-line/-/next-line-1.1.0.tgz",
-      "integrity": "sha1-/K5XhTBStqm66CCOQN19PC0wRgM="
+      "integrity": "sha1-/K5XhTBStqm66CCOQN19PC0wRgM=",
+      "optional": true
     },
     "node-preload": {
       "version": "0.2.1",
@@ -3600,12 +3644,14 @@
     "object-filter-sequence": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/object-filter-sequence/-/object-filter-sequence-1.0.0.tgz",
-      "integrity": "sha512-CsubGNxhIEChNY4cXYuA6KXafztzHqzLLZ/y3Kasf3A+sa3lL9thq3z+7o0pZqzEinjXT6lXDPAfVWI59dUyzQ=="
+      "integrity": "sha512-CsubGNxhIEChNY4cXYuA6KXafztzHqzLLZ/y3Kasf3A+sa3lL9thq3z+7o0pZqzEinjXT6lXDPAfVWI59dUyzQ==",
+      "optional": true
     },
     "object-identity-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/object-identity-map/-/object-identity-map-1.0.2.tgz",
       "integrity": "sha512-a2XZDGyYTngvGS67kWnqVdpoaJWsY7C1GhPJvejWAFCsUioTAaiTu8oBad7c6cI4McZxr4CmvnZeycK05iav5A==",
+      "optional": true,
       "requires": {
         "object.entries": "^1.1.0"
       }
@@ -3672,7 +3718,8 @@
     "optional-js": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/optional-js/-/optional-js-2.3.0.tgz",
-      "integrity": "sha512-B0LLi+Vg+eko++0z/b8zIv57kp7HKEzaPJo7LowJXMUKYdf+3XJGu/cw03h/JhIOsLnP+cG5QnTHAuicjA5fMw=="
+      "integrity": "sha512-B0LLi+Vg+eko++0z/b8zIv57kp7HKEzaPJo7LowJXMUKYdf+3XJGu/cw03h/JhIOsLnP+cG5QnTHAuicjA5fMw==",
+      "optional": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -3692,6 +3739,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/original-url/-/original-url-1.2.3.tgz",
       "integrity": "sha512-BYm+pKYLtS4mVe/mgT3YKGtWV5HzN/XKiaIu1aK4rsxyjuHeTW9N+xVBEpJcY1onB3nccfH0RbzUEoimMqFUHQ==",
+      "optional": true,
       "requires": {
         "forwarded-parse": "^2.1.0"
       }
@@ -3855,7 +3903,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "optional": true
     },
     "psl": {
       "version": "1.8.0",
@@ -3887,7 +3936,8 @@
     "random-poly-fill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/random-poly-fill/-/random-poly-fill-1.0.1.tgz",
-      "integrity": "sha512-bMOL0hLfrNs52+EHtIPIXxn2PxYwXb0qjnKruTjXiM/sKfYqj506aB2plFwWW1HN+ri724bAVVGparh4AtlJKw=="
+      "integrity": "sha512-bMOL0hLfrNs52+EHtIPIXxn2PxYwXb0qjnKruTjXiM/sKfYqj506aB2plFwWW1HN+ri724bAVVGparh4AtlJKw==",
+      "optional": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -3938,15 +3988,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "redact-secrets": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redact-secrets/-/redact-secrets-1.0.0.tgz",
-      "integrity": "sha1-YPHbVpJP6QogO6jMs5KDzbsNkHw=",
-      "requires": {
-        "is-secret": "^1.0.0",
-        "traverse": "^0.6.6"
-      }
-    },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
@@ -3956,7 +3997,8 @@
     "relative-microtime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/relative-microtime/-/relative-microtime-2.0.0.tgz",
-      "integrity": "sha512-l18ha6HEZc+No/uK4GyAnNxgKW7nvEe35IaeN54sShMojtqik2a6GbTyuiezkjpPaqP874Z3lW5ysBo5irz4NA=="
+      "integrity": "sha512-l18ha6HEZc+No/uK4GyAnNxgKW7nvEe35IaeN54sShMojtqik2a6GbTyuiezkjpPaqP874Z3lW5ysBo5irz4NA==",
+      "optional": true
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -3998,7 +4040,8 @@
     "require-ancestors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/require-ancestors/-/require-ancestors-1.0.0.tgz",
-      "integrity": "sha512-Nqeo9Gfp0KvnxTixnxLGEbThMAi+YYgnwRoigtOs1Oo3eGBYfqCd3dagq1vBCVVuc1EnIt3Eu1eGemwOOEZozw=="
+      "integrity": "sha512-Nqeo9Gfp0KvnxTixnxLGEbThMAi+YYgnwRoigtOs1Oo3eGBYfqCd3dagq1vBCVVuc1EnIt3Eu1eGemwOOEZozw==",
+      "optional": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -4006,10 +4049,17 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
     "require-in-the-middle": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.0.3.tgz",
-      "integrity": "sha512-p/ICV8uMlqC4tjOYabLMxAWCIKa0YUQgZZ6KDM0xgXJNgdGQ1WmL2A07TwmrZw+wi6ITUFKzH5v3n+ENEyXVkA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.1.0.tgz",
+      "integrity": "sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==",
+      "optional": true,
       "requires": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -4110,12 +4160,14 @@
     "set-cookie-serde": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/set-cookie-serde/-/set-cookie-serde-1.0.0.tgz",
-      "integrity": "sha512-Vq8e5GsupfJ7okHIvEPcfs5neCo7MZ1ZuWrO3sllYi3DOWt6bSSCpADzqXjz3k0fXehnoFIrmmhty9IN6U6BXQ=="
+      "integrity": "sha512-Vq8e5GsupfJ7okHIvEPcfs5neCo7MZ1ZuWrO3sllYi3DOWt6bSSCpADzqXjz3k0fXehnoFIrmmhty9IN6U6BXQ==",
+      "optional": true
     },
     "shallow-clone-shim": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shallow-clone-shim/-/shallow-clone-shim-2.0.0.tgz",
-      "integrity": "sha512-YRNymdiL3KGOoS67d73TEmk4tdPTO9GSMCoiphQsTcC9EtC+AOmMPjkyBkRoCJfW9ASsaZw1craaiw1dPN2D3Q=="
+      "integrity": "sha512-YRNymdiL3KGOoS67d73TEmk4tdPTO9GSMCoiphQsTcC9EtC+AOmMPjkyBkRoCJfW9ASsaZw1craaiw1dPN2D3Q==",
+      "optional": true
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -4201,20 +4253,38 @@
       }
     },
     "slice-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "astral-regex": "^1.0.0",
-        "is-fullwidth-code-point": "^2.0.0"
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
       },
       "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         }
       }
@@ -4223,6 +4293,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/socket-location/-/socket-location-1.0.0.tgz",
       "integrity": "sha512-TwxpRM0pPE/3b24XQGLx8zq2J8kOwTy40FtiNC1KrWvl/Tsf7RYXruE9icecMhQwicXMo/HUJlGap8DNt2cgYw==",
+      "optional": true,
       "requires": {
         "await-event": "^2.1.0"
       }
@@ -4294,7 +4365,8 @@
     "sql-summary": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sql-summary/-/sql-summary-1.0.1.tgz",
-      "integrity": "sha512-IpCr2tpnNkP3Jera4ncexsZUp0enJBLr+pHCyTweMUBrbJsTgQeLWx1FXLhoBj/MvcnUQpkgOn2EY8FKOkUzww=="
+      "integrity": "sha512-IpCr2tpnNkP3Jera4ncexsZUp0enJBLr+pHCyTweMUBrbJsTgQeLWx1FXLhoBj/MvcnUQpkgOn2EY8FKOkUzww==",
+      "optional": true
     },
     "sshpk": {
       "version": "1.16.1",
@@ -4321,12 +4393,14 @@
     "stackframe": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==",
+      "optional": true
     },
     "stackman": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/stackman/-/stackman-4.0.1.tgz",
       "integrity": "sha512-lntIge3BFEElgvpZT2ld5f4U+mF84fRtJ8vA3ymUVx1euVx43ZMkd09+5RWW4FmvYDFhZwPh1gvtdsdnJyF4Fg==",
+      "optional": true,
       "requires": {
         "after-all-results": "^2.0.0",
         "async-cache": "^1.1.0",
@@ -4339,6 +4413,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/stream-chopper/-/stream-chopper-3.0.1.tgz",
       "integrity": "sha512-f7h+ly8baAE26iIjcp3VbnBkbIRGtrvV0X0xxFM/d7fwLTYnLzDPTXRKNxa2HZzohOrc96NTrR+FaV3mzOelNA==",
+      "optional": true,
       "requires": {
         "readable-stream": "^3.0.6"
       }
@@ -4431,54 +4506,34 @@
       }
     },
     "table": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-      "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
       "dev": true,
       "requires": {
-        "ajv": "^6.10.2",
-        "lodash": "^4.17.14",
-        "slice-ansi": "^2.1.0",
-        "string-width": "^3.0.0"
+        "ajv": "^7.0.2",
+        "lodash": "^4.17.20",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "emoji-regex": {
+        "ajv": {
           "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
           }
         },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
         }
       }
     },
@@ -4523,6 +4578,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/to-source-code/-/to-source-code-1.0.2.tgz",
       "integrity": "sha1-3RNr2x4dvYC76s8IiZJnjpBwv+o=",
+      "optional": true,
       "requires": {
         "is-nil": "^1.0.0"
       }
@@ -4541,6 +4597,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/traceparent/-/traceparent-1.0.0.tgz",
       "integrity": "sha512-b/hAbgx57pANQ6cg2eBguY3oxD6FGVLI1CC2qoi01RmHR7AYpQHPXTig9FkzbWohEsVuHENZHP09aXuw3/LM+w==",
+      "optional": true,
       "requires": {
         "random-poly-fill": "^1.0.1"
       }
@@ -4548,7 +4605,8 @@
     "traverse": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
+      "optional": true
     },
     "triple-beam": {
       "version": "1.3.0",
@@ -4609,6 +4667,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unicode-byte-truncate/-/unicode-byte-truncate-1.0.0.tgz",
       "integrity": "sha1-qm8PNHUZP+IMMgrJIT425i6HZKc=",
+      "optional": true,
       "requires": {
         "is-integer": "^1.0.6",
         "unicode-substring": "^0.1.0"
@@ -4617,7 +4676,8 @@
     "unicode-substring": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/unicode-substring/-/unicode-substring-0.1.0.tgz",
-      "integrity": "sha1-YSDOPDkDhdvND2DDK5BlxBgdSzY="
+      "integrity": "sha1-YSDOPDkDhdvND2DDK5BlxBgdSzY=",
+      "optional": true
     },
     "uri-js": {
       "version": "4.2.2",
@@ -4902,7 +4962,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "optional": true
     },
     "yargs": {
       "version": "13.3.2",

--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "transport",
     "logstash"
   ],
+  "optionalDependencies": {
+    "elastic-apm-node": "^3.9.0"
+  },
   "dependencies": {
     "@elastic/elasticsearch": "^7.10.0",
-    "dayjs": "^1.9.6",
+    "dayjs": "^1.10.4",
     "debug": "^4.3.1",
-    "elastic-apm-node": "^3.9.0",
     "lodash.defaults": "^4.2.0",
     "lodash.omit": "^4.5.0",
     "promise": "^8.1.0",
@@ -47,7 +49,7 @@
   "devDependencies": {
     "babel-eslint": "^10.1.0",
     "coveralls": "^3.1.0",
-    "eslint": "^7.15.0",
+    "eslint": "^7.18.0",
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-json": "^2.1.2",


### PR DESCRIPTION
elastic-apm-node is not yet compatible with node 15
and produces error when installing

the code actually doesn't use this package except for the types in index.d.ts
so we should be able to remove it safely.