### PR TITLE
Set retry limit on BulkWriter in config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,8 +12,7 @@ export interface Transformer {
   (logData: LogData): any;
 }
 
-export interface ElasticsearchTransportOptions
-  extends TransportStream.TransportStreamOptions {
+export interface ElasticsearchTransportOptions extends TransportStream.TransportStreamOptions {
   dataStream?: boolean;
   apm?: any; // typeof Agent;
   timestamp?: () => string;
@@ -25,7 +24,7 @@ export interface ElasticsearchTransportOptions
   indexTemplate?: { [key: string]: any };
   ensureIndexTemplate?: boolean;
   flushInterval?: number;
-  waitForActiveShards?: number | "all";
+  waitForActiveShards?: number | 'all';
   handleExceptions?: boolean;
   pipeline?: string;
   client?: Client;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import { Client, ClientOptions, ApiResponse } from "@elastic/elasticsearch";
-import TransportStream = require("winston-transport");
+import { Client, ClientOptions, ApiResponse } from '@elastic/elasticsearch';
+import TransportStream = require('winston-transport');
 
 export interface LogData {
   message: any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
-import { Client, ClientOptions, ApiResponse } from '@elastic/elasticsearch';
-import TransportStream = require('winston-transport');
+import { Client, ClientOptions, ApiResponse } from "@elastic/elasticsearch";
+import TransportStream = require("winston-transport");
 
 export interface LogData {
   message: any;
@@ -12,7 +12,8 @@ export interface Transformer {
   (logData: LogData): any;
 }
 
-export interface ElasticsearchTransportOptions extends TransportStream.TransportStreamOptions {
+export interface ElasticsearchTransportOptions
+  extends TransportStream.TransportStreamOptions {
   dataStream?: boolean;
   apm?: any; // typeof Agent;
   timestamp?: () => string;
@@ -24,7 +25,7 @@ export interface ElasticsearchTransportOptions extends TransportStream.Transport
   indexTemplate?: { [key: string]: any };
   ensureIndexTemplate?: boolean;
   flushInterval?: number;
-  waitForActiveShards?: number | 'all';
+  waitForActiveShards?: number | "all";
   handleExceptions?: boolean;
   pipeline?: string;
   client?: Client;
@@ -35,6 +36,7 @@ export interface ElasticsearchTransportOptions extends TransportStream.Transport
   healthCheckWaitForStatus?: string;
   healthCheckWaitForNodes?: string;
   source?: string;
+  retryLimit: number;
 }
 
 export class ElasticsearchTransport extends TransportStream {

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ export interface ElasticsearchTransportOptions extends TransportStream.Transport
   healthCheckWaitForStatus?: string;
   healthCheckWaitForNodes?: string;
   source?: string;
-  retryLimit: number;
+  retryLimit?: number;
 }
 
 export class ElasticsearchTransport extends TransportStream {

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ class ElasticsearchTransport extends Transport {
       healthCheckWaitForStatus: 'yellow',
       healthCheckWaitForNodes: '>=1',
       dataStream: false,
+      retryLimit: 400
     });
 
     // Use given client or create one
@@ -83,7 +84,8 @@ class ElasticsearchTransport extends Transport {
       healthCheckTimeout: opts.healthCheckTimeout,
       healthCheckWaitForStatus: opts.healthCheckWaitForStatus,
       healthCheckWaitForNodes: opts.healthCheckWaitForNodes,
-      dataStream: opts.dataStream
+      dataStream: opts.dataStream,
+      retryLimit: opts.retryLimit
     };
 
     this.bulkWriter = new BulkWriter(this, this.client, bulkWriterOpts);

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ class ElasticsearchTransport extends Transport {
       healthCheckTimeout: '30s',
       healthCheckWaitForStatus: 'yellow',
       healthCheckWaitForNodes: '>=1',
-      dataStream: false
+      dataStream: false,
     });
 
     // Use given client or create one

--- a/index.js
+++ b/index.js
@@ -47,8 +47,7 @@ class ElasticsearchTransport extends Transport {
       healthCheckTimeout: '30s',
       healthCheckWaitForStatus: 'yellow',
       healthCheckWaitForNodes: '>=1',
-      dataStream: false,
-      retryLimit: 400
+      dataStream: false
     });
 
     // Use given client or create one


### PR DESCRIPTION
This passes through a retryLimit from the index into the BulkWriter options to allow you to choose how many times to retry (rather than just using 400)

Related to this: https://github.com/vanthome/winston-elasticsearch/issues/165 but it doesn't fix the duplicate retry problem. 