### PR TITLE
Export the default transformer

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,20 @@ Output A:
 }
 ```
 
+The default transformer can be imported and extended
+## Example
+```js
+  const { ElasticsearchTransformer } = require('winston-elasticsearch');
+  const esTransportOpts = {
+  transformer: (logData) => {
+   const transformed = ElasticsearchTransformer(logdata);
+   transformed.meta.customField = 'customValue'
+   return transformed;
+ }};
+const esTransport = new ElasticsearchTransport(esTransportOpts);
+
+```
+
 Note that in current logstash versions, the only "standard fields" are
 `@timestamp` and `@version`, anything else is just free.
 

--- a/index.js
+++ b/index.js
@@ -175,5 +175,6 @@ class ElasticsearchTransport extends Transport {
 winston.transports.Elasticsearch = ElasticsearchTransport;
 
 module.exports = {
-  ElasticsearchTransport
+  ElasticsearchTransport,
+  ElasticsearchTransformer: defaultTransformer
 };


### PR DESCRIPTION
There is no way to extend the default transformer, This PR allow importing the default transformer and show an example of how to extend it.