### PR TITLE
Add export type declaration for ElasticsearchTransformer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,3 +46,15 @@ export class ElasticsearchTransport extends TransportStream {
   query<T>(q: string): Promise<ApiResponse<T>>;
   getIndexName(opts: ElasticsearchTransportOptions): string;
 }
+
+interface TransformedData {
+  '@timestamp': string
+  message: string
+  severity: string
+  fields: string
+  transaction?: { id: string }
+  trace?: { id: string }
+  span?: { id: string }
+}
+
+export function ElasticsearchTransformer(logData: LogData): TransformedData;


### PR DESCRIPTION
There is no way to import `ElasticsearchTransformer` with type declaration on typescript, This PR allow import `ElasticsearchTransformer` with type declaration.

Related with: [PR#186](https://github.com/vanthome/winston-elasticsearch/pull/186)