### PR TITLE
fix: elasticsearch 8 support

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -126,7 +126,7 @@ BulkWriter.prototype.write = function write(body) {
   return this.client
     .bulk({
       body,
-      waitForActiveShards: this.waitForActiveShards,
+      wait_for_active_shards: this.waitForActiveShards,
       timeout: this.interval + 'ms',
     })
     .then((response) => {


### PR DESCRIPTION
The node client for elasticsearch 8 [removed automatically converting options to train_case](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/8.0/changelog-client.html#_drop_support_for_old_camelcased_keys). This seems to be all that's required for es8 support