### PR TITLE
Fix data type of TransformedData.fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ interface TransformedData {
   '@timestamp': string
   message: string
   severity: string
-  fields: string
+  fields: any
   transaction?: { id: string }
   trace?: { id: string }
   span?: { id: string }


### PR DESCRIPTION
The real type of Transfromed.fields is Object, not string.
So If we define this type as string, we cannot use `TransformedDAta.fields`.


As you can see, the real data type of `TransformedDAta.fields` is Object, not string.
![image](https://user-images.githubusercontent.com/48897274/179663677-fa0c20ab-a98c-4caf-a248-63ab9b30e989.png)
