### PR TITLE
Bug: Fix regression bug of duplicate message

### DIFF
--- a/bulk_writer.js
+++ b/bulk_writer.js
@@ -134,6 +134,7 @@ BulkWriter.prototype.write = function write(body) {
       if (res && res.errors && res.items) {
         const err = new Error('Elasticsearch error');
         res.items.forEach((item, itemIndex) => {
+          const bodyOp = body[itemIndex * 2];
           const bodyData = body[itemIndex * 2 + 1];
           const opKey = Object.keys(item)[0];
           if (item[opKey] && item[opKey].error) {
@@ -141,6 +142,8 @@ BulkWriter.prototype.write = function write(body) {
             thiz.options.internalLogger('elasticsearch indexing error', item[opKey].error, bodyData);
             err.indexError = item[opKey].error;
             err.causedBy = bodyData;
+          } else if (item[opKey] && item[opKey].result === 'created') {
+            bodyOp.created = true;
           }
         });
         throw err;


### PR DESCRIPTION
I found a regression bug which cause duplicate message when ES error occur.
1. This commit will fix issue #219.
2. This regression introduced in commit https://github.com/vanthome/winston-elasticsearch/commit/82896f1406472ab7c4eddc5ca03b35070728654a#diff-8fd595d5134a276ec8bae2762c4b3ff120b3a121a16282147614daccb90e1f01

Pls review, thanks.